### PR TITLE
feat: route review alias through Cursor

### DIFF
--- a/cursor/.cursor/cli-config.json
+++ b/cursor/.cursor/cli-config.json
@@ -1,0 +1,41 @@
+{
+  "permissions": {
+    "allow": [
+      "Shell(ls)",
+      "Shell(git)",
+      "Shell(gh)",
+      "Shell(gt)"
+    ],
+    "deny": []
+  },
+  "version": 1,
+  "editor": {
+    "vimMode": false
+  },
+  "model": {
+    "modelId": "gpt-5.4-high",
+    "displayModelId": "gpt-5.4-high",
+    "displayName": "GPT-5.4 1M High",
+    "displayNameShort": "GPT-5.4 1M High",
+    "aliases": [],
+    "maxMode": false
+  },
+  "hasChangedDefaultModel": true,
+  "maxMode": false,
+  "modelParameters": {
+    "gpt-5.4-high": []
+  },
+  "selectedModel": {
+    "modelId": "gpt-5.4-high",
+    "parameters": []
+  },
+  "privacyCache": {
+    "ghostMode": true,
+    "privacyMode": 1,
+    "updatedAt": 1774676960092
+  },
+  "attribution": {
+    "attributeCommitsToAgent": false,
+    "attributePRsToAgent": false
+  }
+}

--- a/cursor/.cursor/skills/review/SKILL.md
+++ b/cursor/.cursor/skills/review/SKILL.md
@@ -87,6 +87,9 @@ Use this structure:
 ## Open Questions
 - Anything ambiguous or worth confirming
 
+## Merge Recommendation
+Ready, Ready with follow-ups, or Needs changes.
+
 ## Summary
 Short overview of what the PR does and any remaining risk areas.
 ```
@@ -94,8 +97,10 @@ Short overview of what the PR does and any remaining risk areas.
 ## Review rules
 
 - Be concise but specific.
+- Respond with exactly these sections in this order: Findings, Open Questions, Merge Recommendation, Summary.
+- Report only concrete, evidence-backed issues.
 - Include file paths or symbols for each finding.
 - Explain why the issue matters, not just what changed.
 - Suggest a concrete fix or follow-up test when possible.
-- If no meaningful issues are found, say so explicitly and mention any residual risks or missing tests.
-- Do not invent problems to fill the template.
+- If there are no concrete findings, write `None` under Findings.
+- Use exactly one merge recommendation: `Ready`, `Ready with follow-ups`, or `Needs changes`.

--- a/fish/.config/fish/functions/review.fish
+++ b/fish/.config/fish/functions/review.fish
@@ -17,6 +17,8 @@ function review
         return 1
     end
 
+    set -l review_model gpt-5.4-high
+
     # pane identities
     # 0 - top left
     # 1 - top right
@@ -42,17 +44,17 @@ function review
     end
 
     # send review commands to each pane
-    echo -e "claude 'Your name is Evelyn. Use /review to review PR #$pr_number. Do not mutate the PR in any way, just provide a review.'" | wezterm cli send-text --no-paste --pane-id $pane_0
+    printf '%s\r' "cursor-agent --mode=ask --model $review_model \"You are Evelyn. Use the local review skill to review PR #$pr_number in read-only mode and follow its exact response format.\"" | wezterm cli send-text --no-paste --pane-id $pane_0
 
     if test $num_panes -ge 2
-        echo -e "claude 'Your name is Vivian. Use /review to review PR #$pr_number. Do not mutate the PR in any way, just provide a review.'" | wezterm cli send-text --no-paste --pane-id $pane_1
+        printf '%s\r' "cursor-agent --mode=ask --model $review_model \"You are Vivian. Use the local review skill to review PR #$pr_number in read-only mode and follow its exact response format.\"" | wezterm cli send-text --no-paste --pane-id $pane_1
     end
 
     if test $num_panes -ge 3
-        echo -e "claude 'Your name is Stella. Use /review to review PR #$pr_number. Focus on critical bugs, security vulnerabilities, and logic errors. Do not mutate the PR in any way, just provide a review.'" | wezterm cli send-text --no-paste --pane-id $pane_2
+        printf '%s\r' "cursor-agent --mode=ask --model $review_model \"You are Stella. Use the local review skill to review PR #$pr_number in read-only mode and follow its exact response format. Focus on critical bugs, security vulnerabilities, and logic errors.\"" | wezterm cli send-text --no-paste --pane-id $pane_2
     end
 
     if test $num_panes -ge 4
-        echo -e "claude 'Your name is Tiffany. Use /review to review PR #$pr_number. Focus on dead code, unused imports, and unreachable code paths. Do not mutate the PR in any way, just provide a review.'" | wezterm cli send-text --no-paste --pane-id $pane_3
+        printf '%s\r' "cursor-agent --mode=ask --model $review_model \"You are Tiffany. Use the local review skill to review PR #$pr_number in read-only mode and follow its exact response format. Focus on dead code, unused imports, and unreachable code paths.\"" | wezterm cli send-text --no-paste --pane-id $pane_3
     end
 end


### PR DESCRIPTION
## Summary
Switch the `review` fish function from Claude to `cursor-agent` so the `r` alias uses the local Cursor `review` skill for multi-pane PR reviews.

## Commentary
Keeps the existing WezTerm pane fan-out behavior while making the review prompts read-only and Graphite-aware for stacked branches.