### PR TITLE
feat: add review_auto fish function for automated review/triage/fix loop

### DIFF
--- a/docs/spec/2026-04-12-review-auto.md
+++ b/docs/spec/2026-04-12-review-auto.md
@@ -10,7 +10,7 @@ The current review workflow is manual and sequential:
 
 1. Write code with Cursor CLI (`c` / `cursor-agent --yolo`)
 2. Run `review` — spawns 4 wezterm panes, each running a review agent (Evelyn, Vivian, Stella, Tiffany) against the current PR
-3. Wait for all 4 reviewers to finish
+3. Wait for all 3 reviewers to finish
 4. Manually read each review, decide which findings are real
 5. Ask a new agent to fix the real findings
 6. Re-run `review` to verify fixes
@@ -77,7 +77,6 @@ Each agent writes its output to a temp file so downstream agents can read it:
     review_evelyn.md
     review_vivian.md
     review_stella.md
-    review_tiffany.md
     triage.md
   round_2/
     ...
@@ -87,27 +86,28 @@ Each round gets its own subdirectory so previous rounds are preserved for debugg
 
 ### Wezterm pane layout
 
-Fixed 5-pane layout for the entire session:
+Fixed 4-quadrant layout for the entire session:
 
 ```
 ┌─────────────────────┬─────────────────────┐
 │   ORCHESTRATOR      │      Evelyn         │
-├───────────┬─────────┴───────┬─────────────┤
-│ Vivian    │    Stella       │   Tiffany   │
-└───────────┴─────────────────┴─────────────┘
+├─────────────────────┼─────────────────────┤
+│     Vivian          │      Stella         │
+└─────────────────────┴─────────────────────┘
 ```
 
-- **Top row:** 2 panes — orchestrator (left) polls and prints status, Evelyn (right) is the first reviewer and later runs triage/fix.
-- **Bottom row:** 3 panes — Vivian, Stella, Tiffany. The remaining reviewers run in parallel.
+- **Top-left:** Orchestrator — polls for completion, prints status.
+- **Top-right:** Evelyn — first reviewer, later runs triage/fix.
+- **Bottom-left:** Vivian — second reviewer.
+- **Bottom-right:** Stella — third reviewer.
 
-All agents run in full TUI mode (not `--print`) so you can watch their progress live. The orchestrator pane only shows status text and polls for completion.
+All agents run in full TUI mode (not `--print`) so you can watch their progress live.
 
-Split order:
+Split order (same pattern as `wez_quadrants.example.fish`):
 1. pane_0 = `$WEZTERM_PANE` (orchestrator, top-left)
-2. pane_evelyn = `split-pane --pane-id $pane_0 --right` (top-right)
-3. pane_vivian = `split-pane --pane-id $pane_0 --bottom` (bottom-left)
-4. pane_stella = `split-pane --pane-id $pane_vivian --right` (bottom-center)
-5. pane_tiffany = `split-pane --pane-id $pane_stella --right` (bottom-right)
+2. pane_bottom_left = `split-pane --pane-id $pane_0 --bottom` (Vivian)
+3. pane_bottom_right = `split-pane --pane-id $pane_bottom_left --right` (Stella)
+4. pane_top_right = `split-pane --pane-id $pane_0 --right` (Evelyn)
 
 All panes persist across rounds — review panes are reused each cycle. After reviewers finish, triage and fix run in Evelyn's pane (top-right).
 
@@ -132,14 +132,13 @@ Verified: this correctly returns true when an agent is running and false when it
 The triage agent runs in Evelyn's pane (top-right) after reviewers finish. It reads the review output files itself (has `--yolo` tool access) rather than receiving them inline — review outputs can be very long.
 
 ```
-You are a senior code-review triage agent. Read the 4 review output files at:
+You are a senior code-review triage agent. Read the 3 review output files at:
   {round_dir}/review_evelyn.md
   {round_dir}/review_vivian.md
   {round_dir}/review_stella.md
-  {round_dir}/review_tiffany.md
 
 Your job:
-- Read all 4 reviews
+- Read all 3 reviews
 - Filter out nitpicks, style-only comments, and false positives
 - Output ONLY the issues that are real bugs, logic errors, security
   vulnerabilities, or missing error handling
@@ -168,7 +167,7 @@ Default cap of 3 iterations to prevent infinite loops. Configurable via argument
 review_auto [options]
   --max-rounds N     Max review/fix cycles (default: 3)
   --provider NAME    openai | anthropic (default: anthropic)
-  --panes N          Number of review panes 1-4 (default: 4)
+  --panes N          Number of review panes 1-3 (default: 3)
   --dry-run          Run reviews + triage only, skip fix step
 ```
 
@@ -219,7 +218,7 @@ Each agent writes its output via Write tool and touches a sentinel file via Shel
 
 ### Cleanup
 
-When the loop exits (clean PR or max rounds hit), the 4 review panes are left open so the user can scroll through the last round's output. The orchestrator pane prints a summary (rounds completed, final status) and returns control to the shell.
+When the loop exits (clean PR or max rounds hit), the 3 review panes are left open so the user can scroll through the last round's output. The orchestrator pane prints a summary (rounds completed, final status) and returns control to the shell.
 
 ## Open questions
 

--- a/docs/spec/2026-04-12-review-auto.md
+++ b/docs/spec/2026-04-12-review-auto.md
@@ -73,16 +73,16 @@ Each agent writes its output to a temp file so downstream agents can read it:
 
 ```
 /tmp/review_auto.<session>/
-  round_1/
+  iter_1/
     review_evelyn.md
     review_vivian.md
     review_stella.md
     triage.md
-  round_2/
+  iter_2/
     ...
 ```
 
-Each round gets its own subdirectory so previous rounds are preserved for debugging. All agents write their output via the Write tool and run in full TUI mode.
+Each iteration gets its own subdirectory so previous iterations are preserved for debugging. All agents write their output via the Write tool and run in full TUI mode.
 
 ### Wezterm pane layout
 
@@ -117,7 +117,7 @@ Two complementary mechanisms (both verified working):
 
 **Primary — sentinel files:** Each review agent is instructed to touch a sentinel file via Shell tool when done:
 ```
-cursor-agent --yolo --model MODEL "... Then run this shell command: touch /tmp/review_auto.xxx/round_1/.done_evelyn"
+cursor-agent --yolo --model MODEL "... Then run this shell command: touch /tmp/review_auto.xxx/iter_1/.done_evelyn"
 ```
 The orchestrator polls for all `.done_*` files to exist. If an agent crashes before touching the sentinel, the orchestrator will wait indefinitely — but this is rare and the user can Ctrl+C to abort.
 
@@ -129,18 +129,18 @@ Verified: this correctly returns true when an agent is running and false when it
 
 ### Triage agent prompt
 
-The triage agent runs in a fresh work pane (right of orchestrator) after reviewers finish. The prompt is written to a file `{round_dir}/triage_prompt.txt` and the agent is told to read it:
+The triage agent runs in a fresh work pane (right of orchestrator) after reviewers finish. The prompt is written to a file `{iter_dir}/triage_prompt.txt` and the agent is told to read it:
 
 ```
-cursor-agent --yolo --model MODEL "Read the prompt at {round_dir}/triage_prompt.txt and follow its instructions exactly."
+cursor-agent --yolo --model MODEL "Read the prompt at {iter_dir}/triage_prompt.txt and follow its instructions exactly."
 ```
 
 The prompt file contains:
 ```
 You are a code-review triage agent. Read the 3 review output files at:
-  {round_dir}/review_evelyn.md
-  {round_dir}/review_vivian.md
-  {round_dir}/review_stella.md
+  {iter_dir}/review_evelyn.md
+  {iter_dir}/review_vivian.md
+  {iter_dir}/review_stella.md
 
 Your job:
 - Read all 3 reviews
@@ -150,18 +150,18 @@ Your job:
 - If a review file is empty or contains an error, skip it
 - If there are no real issues, output exactly: NO_ISSUES_FOUND
 - Format each real issue as a structured block with file, line, description, and severity
-- Write your final verdict to {round_dir}/triage.md using the Write tool
-- When done, run: touch {round_dir}/.done_triage
+- Write your final verdict to {iter_dir}/triage.md using the Write tool
+- When done, run: touch {iter_dir}/.done_triage
 ```
 
 ### Fix agent prompt
 
-The fix agent runs in the same work pane after triage completes. Prompt is also written to a file `{round_dir}/fix_prompt.txt`:
+The fix agent runs in a fresh work pane after triage completes. Prompt is also written to a file `{iter_dir}/fix_prompt.txt`:
 
 ```
-Read the triaged issues at {round_dir}/triage.md.
+Read the triaged issues at {iter_dir}/triage.md.
 Fix every issue listed. Do not fix anything not listed. Commit your changes
-with a clear message referencing the fixes. When done, run: touch {round_dir}/.done_fix
+with a clear message referencing the fixes. When done, run: touch {iter_dir}/.done_fix
 ```
 
 ### Max iterations
@@ -172,7 +172,7 @@ Default cap of 3 iterations to prevent infinite loops. Configurable via argument
 
 ```
 review_auto [options]
-  --max-rounds N     Max review/fix cycles (default: 3)
+  --max-iterations N Max review/fix cycles (default: 3)
   --provider NAME    openai | anthropic (default: anthropic)
   --panes N          Number of review panes 1-3 (default: 3)
   --dry-run          Run reviews + triage only, skip fix step
@@ -187,7 +187,7 @@ review_auto [options]
 | Triage sentinel | `NO_ISSUES_FOUND` in triage.md | Simple, grep-able exit condition |
 | Fix agent mode | `--yolo` (full write access) | Needs to edit files, run shell tools, and commit |
 | Review agents | `--yolo` (full TUI) | Without `--yolo`, agents can't run shell tools (gh cli, git, etc.) needed for PR inspection |
-| Loop cap | 3 rounds | Prevents runaway; most real issues resolve in 1-2 rounds |
+| Loop cap | 3 iterations | Prevents runaway; most real issues resolve in 1-2 iterations |
 
 ## Feasibility findings
 
@@ -212,7 +212,7 @@ Tested against `cursor-agent` CLI and `wezterm cli` on 2026-04-12. All core mech
 
 ### Pane lifecycle
 
-- Using `send-text` approach (same as existing `review.fish`): the pane has a persistent fish shell. After cursor-agent exits, the shell stays — the pane doesn't close. This is good: we can reuse panes across rounds.
+- Using `send-text` approach (same as existing `review.fish`): the pane has a persistent fish shell. After cursor-agent exits, the shell stays — the pane doesn't close. This is good: we can reuse panes across iterations.
 - Alternative `split-pane -- fish -c "cmd"` approach: pane runs one command and then the shell exits. Pane behavior on exit depends on wezterm `exit_behavior` config (default `CloseOnCleanExit`). **Not recommended** — we want persistent panes for reuse and visibility.
 
 ### Confirmed approach
@@ -228,16 +228,16 @@ Each reviewer writes its output via Write tool and touches a sentinel file via S
 **Triage/Fix phase:**
 After review completes, reviewer panes are killed. A fresh work pane is created on the right of the orchestrator. Prompts are written to temp files to avoid quote/newline escaping issues with send-text:
 ```
-echo "LONG PROMPT..." > {round_dir}/triage_prompt.txt
-cursor-agent --yolo --model MODEL "Read the prompt at {round_dir}/triage_prompt.txt and follow its instructions exactly."
+echo "LONG PROMPT..." > {iter_dir}/triage_prompt.txt
+cursor-agent --yolo --model MODEL "Read the prompt at {iter_dir}/triage_prompt.txt and follow its instructions exactly."
 ```
 Orchestrator pane polls for `.done_*` files and prints status.
 
 ### Cleanup
 
-After each review phase, reviewer panes are killed to create a clean work pane for triage/fix. After triage/fix completes, the work pane is killed before the next round. When the loop exits (clean PR or max rounds hit), the orchestrator pane prints a summary (rounds completed, final status) and returns control to the shell.
+After each review phase, reviewer panes are killed to create a clean work pane for triage/fix. After triage/fix completes, the work pane is killed before the next iteration. When the loop exits (clean PR or max iterations hit), the orchestrator pane prints a summary and returns control to the shell.
 
 ## Open questions
 
-- Should the function auto-push after a clean round, or leave that to the user?
+- Should the function auto-push after a clean iteration, or leave that to the user?
 - Should there be a `--notify` flag to send a macOS notification when done?

--- a/docs/spec/2026-04-12-review-auto.md
+++ b/docs/spec/2026-04-12-review-auto.md
@@ -109,7 +109,7 @@ Split order (same pattern as `wez_quadrants.example.fish`):
 3. pane_bottom_right = `split-pane --pane-id $pane_bottom_left --right` (Stella)
 4. pane_top_right = `split-pane --pane-id $pane_0 --right` (Evelyn)
 
-All panes persist across rounds — review panes are reused each cycle. After reviewers finish, triage and fix run in Evelyn's pane (top-right).
+**After review phase:** All reviewer panes are killed. A fresh work pane is created on the right side of the orchestrator for triage/fix. This avoids the complexity of reusing panes and ensures clean agent startup.
 
 ### Waiting for agents to finish
 
@@ -129,8 +129,13 @@ Verified: this correctly returns true when an agent is running and false when it
 
 ### Triage agent prompt
 
-The triage agent runs in Evelyn's pane (top-right) after reviewers finish. It reads the review output files itself (has `--yolo` tool access) rather than receiving them inline — review outputs can be very long.
+The triage agent runs in a fresh work pane (right of orchestrator) after reviewers finish. The prompt is written to a file `{round_dir}/triage_prompt.txt` and the agent is told to read it:
 
+```
+cursor-agent --yolo --model MODEL "Read the prompt at {round_dir}/triage_prompt.txt and follow its instructions exactly."
+```
+
+The prompt file contains:
 ```
 You are a senior code-review triage agent. Read the 3 review output files at:
   {round_dir}/review_evelyn.md
@@ -145,16 +150,18 @@ Your job:
 - If a review file is empty or contains an error, skip it
 - If there are no real issues, output exactly: NO_ISSUES_FOUND
 - Format each real issue as a structured block with file, line, description, and severity
+- Write your final verdict to {round_dir}/triage.md using the Write tool
+- When done, run: touch {round_dir}/.done_triage
 ```
 
 ### Fix agent prompt
 
-The fix agent also runs in Evelyn's pane (top-right). It reads the triage output file.
+The fix agent runs in the same work pane after triage completes. Prompt is also written to a file `{round_dir}/fix_prompt.txt`:
 
 ```
 You are a senior engineer. Read the triaged issues at {round_dir}/triage.md.
 Fix every issue listed. Do not fix anything not listed. Commit your changes
-with a clear message referencing the fixes.
+with a clear message referencing the fixes. When done, run: touch {round_dir}/.done_fix
 ```
 
 ### Max iterations
@@ -210,15 +217,25 @@ Tested against `cursor-agent` CLI and `wezterm cli` on 2026-04-12. All core mech
 
 ### Confirmed approach
 
-Use `send-text` for all agents (matching existing `review.fish` pattern). Each pane has a fish shell. All agents run in full TUI mode (no `--print`) so you can watch agent progress live:
+Use `send-text` for all agents (matching existing `review.fish` pattern). Each pane has a fish shell. All agents run in full TUI mode (no `--print`) so you can watch agent progress live.
+
+**Review phase:**
 ```
 cursor-agent --yolo --model MODEL "PROMPT (write output to FILE, then run: touch SENTINEL)"
 ```
-Each agent writes its output via Write tool and touches a sentinel file via Shell tool when done. Orchestrator pane polls for `.done_*` files and prints status. Triage/fix reuse Evelyn's pane (top-right) after reviewers finish.
+Each reviewer writes its output via Write tool and touches a sentinel file via Shell tool when done.
+
+**Triage/Fix phase:**
+After review completes, reviewer panes are killed. A fresh work pane is created on the right of the orchestrator. Prompts are written to temp files to avoid quote/newline escaping issues with send-text:
+```
+echo "LONG PROMPT..." > {round_dir}/triage_prompt.txt
+cursor-agent --yolo --model MODEL "Read the prompt at {round_dir}/triage_prompt.txt and follow its instructions exactly."
+```
+Orchestrator pane polls for `.done_*` files and prints status.
 
 ### Cleanup
 
-When the loop exits (clean PR or max rounds hit), the 3 review panes are left open so the user can scroll through the last round's output. The orchestrator pane prints a summary (rounds completed, final status) and returns control to the shell.
+After each review phase, reviewer panes are killed to create a clean work pane for triage/fix. After triage/fix completes, the work pane is killed before the next round. When the loop exits (clean PR or max rounds hit), the orchestrator pane prints a summary (rounds completed, final status) and returns control to the shell.
 
 ## Open questions
 

--- a/docs/spec/2026-04-12-review-auto.md
+++ b/docs/spec/2026-04-12-review-auto.md
@@ -83,43 +83,43 @@ Each agent writes its output to a temp file so downstream agents can read it:
     ...
 ```
 
-Each round gets its own subdirectory so previous rounds are preserved for debugging. `cursor-agent --print` mode writes to stdout, which we tee into these files. This also means each pane shows live output to the user.
+Each round gets its own subdirectory so previous rounds are preserved for debugging. All agents write their output via the Write tool and run in full TUI mode.
 
 ### Wezterm pane layout
 
 Fixed 5-pane layout for the entire session:
 
 ```
-┌─────────────────────────────────────────────┐
-│              ORCHESTRATOR (pane 0)           │
-│  triage agent / fix agent / status output   │
-├──────────┬──────────┬──────────┬────────────┤
-│ Evelyn   │ Vivian   │ Stella   │ Tiffany    │
-│ (pane 1) │ (pane 2) │ (pane 3) │ (pane 4)   │
-└──────────┴──────────┴──────────┴────────────┘
+┌─────────────────────┬─────────────────────┐
+│   ORCHESTRATOR      │      Evelyn         │
+├───────────┬─────────┴───────┬─────────────┤
+│ Vivian    │    Stella       │   Tiffany   │
+└───────────┴─────────────────┴─────────────┘
 ```
 
-- **Top row:** 1 wide pane — the orchestrator. The fish function lives here, running triage and fix agents as direct subprocesses (`cursor-agent --print ... | tee file`). Output streams live to this pane. The function blocks on each subprocess, so there's no conflict between polling and agent output.
-- **Bottom row:** 4 equal panes — the 4 review agents. Run in parallel each round via `send-text`.
+- **Top row:** 2 panes — orchestrator (left) polls and prints status, Evelyn (right) is the first reviewer and later runs triage/fix.
+- **Bottom row:** 3 panes — Vivian, Stella, Tiffany. The remaining reviewers run in parallel.
 
-Split order (verified with `wezterm cli split-pane`):
-1. pane_0 = `$WEZTERM_PANE` (orchestrator, top)
-2. pane_1 = `split-pane --pane-id $pane_0 --bottom --percent 70` (first reviewer, bottom-left)
-3. pane_2 = `split-pane --pane-id $pane_1 --right` (bottom splits 50/50)
-4. pane_3 = `split-pane --pane-id $pane_1 --right` (left half splits again → 25/25)
-5. pane_4 = `split-pane --pane-id $pane_2 --right` (right half splits again → 25/25)
+All agents run in full TUI mode (not `--print`) so you can watch their progress live. The orchestrator pane only shows status text and polls for completion.
 
-Bottom row gets 70% of vertical space since reviewers produce the most output. All panes persist across rounds — review panes are reused each cycle, orchestrator pane runs triage then fix sequentially between review rounds.
+Split order:
+1. pane_0 = `$WEZTERM_PANE` (orchestrator, top-left)
+2. pane_evelyn = `split-pane --pane-id $pane_0 --right` (top-right)
+3. pane_vivian = `split-pane --pane-id $pane_0 --bottom` (bottom-left)
+4. pane_stella = `split-pane --pane-id $pane_vivian --right` (bottom-center)
+5. pane_tiffany = `split-pane --pane-id $pane_stella --right` (bottom-right)
+
+All panes persist across rounds — review panes are reused each cycle. After reviewers finish, triage and fix run in Evelyn's pane (top-right).
 
 ### Waiting for agents to finish
 
 Two complementary mechanisms (both verified working):
 
-**Primary — sentinel files:** Each review command is chained with a `touch`:
-```fish
-cursor-agent --print ... | tee /tmp/review_auto.xxx/round_1/review_evelyn.md; touch /tmp/review_auto.xxx/round_1/.done_evelyn
+**Primary — sentinel files:** Each review agent is instructed to touch a sentinel file via Shell tool when done:
 ```
-The orchestrator polls for all `.done_*` files to exist. Simple, race-free, works even if the agent crashes (the touch still runs because it's `;`-chained, not `&&`-chained). Empty or error output is handled gracefully by the triage agent (it skips empty files).
+cursor-agent --yolo --model MODEL "... Then run this shell command: touch /tmp/review_auto.xxx/round_1/.done_evelyn"
+```
+The orchestrator polls for all `.done_*` files to exist. If an agent crashes before touching the sentinel, the orchestrator will wait indefinitely — but this is rare and the user can Ctrl+C to abort.
 
 **Fallback — TTY process check:** `wezterm cli list --format json` exposes `tty_name` for each pane. We can verify no `cursor-agent` process is running on a pane's TTY:
 ```fish
@@ -129,7 +129,7 @@ Verified: this correctly returns true when an agent is running and false when it
 
 ### Triage agent prompt
 
-The triage agent runs as a direct subprocess in the orchestrator pane. It reads the review output files itself (has `--yolo` tool access) rather than receiving them inline — review outputs can be very long.
+The triage agent runs in Evelyn's pane (top-right) after reviewers finish. It reads the review output files itself (has `--yolo` tool access) rather than receiving them inline — review outputs can be very long.
 
 ```
 You are a senior code-review triage agent. Read the 4 review output files at:
@@ -150,7 +150,7 @@ Your job:
 
 ### Fix agent prompt
 
-The fix agent also runs as a direct subprocess in the orchestrator pane. It reads the triage output file.
+The fix agent also runs in Evelyn's pane (top-right). It reads the triage output file.
 
 ```
 You are a senior engineer. Read the triaged issues at {round_dir}/triage.md.
@@ -176,10 +176,11 @@ review_auto [options]
 
 | Decision | Choice | Rationale |
 |---|---|---|
-| Output format | `--print` to file via tee | Gives visible terminal output AND machine-readable files for the next agent |
-| Triage sentinel | `NO_ISSUES_FOUND` string | Simple, grep-able exit condition |
+| All agents | Full TUI mode (no `--print`) | Live progress visible in all panes |
+| Output files | Agents write via Write tool | Agent controls file output; no pipe buffering |
+| Triage sentinel | `NO_ISSUES_FOUND` in triage.md | Simple, grep-able exit condition |
 | Fix agent mode | `--yolo` (full write access) | Needs to edit files, run shell tools, and commit |
-| Review agents | `--yolo --print` | Without `--yolo`, agents can't run shell tools (gh cli, git, etc.) needed for PR inspection |
+| Review agents | `--yolo` (full TUI) | Without `--yolo`, agents can't run shell tools (gh cli, git, etc.) needed for PR inspection |
 | Loop cap | 3 rounds | Prevents runaway; most real issues resolve in 1-2 rounds |
 
 ## Feasibility findings
@@ -210,11 +211,11 @@ Tested against `cursor-agent` CLI and `wezterm cli` on 2026-04-12. All core mech
 
 ### Confirmed approach
 
-Use `send-text` (matching existing `review.fish` pattern). Each pane has a fish shell. We send commands like:
+Use `send-text` for all agents (matching existing `review.fish` pattern). Each pane has a fish shell. All agents run in full TUI mode (no `--print`) so you can watch agent progress live:
 ```
-cursor-agent --yolo --print --trust --model MODEL -p "PROMPT" 2>&1 | tee /tmp/session/review_NAME.md; touch /tmp/session/.done_NAME\r
+cursor-agent --yolo --model MODEL "PROMPT (write output to FILE, then run: touch SENTINEL)"
 ```
-Orchestrator pane polls for `.done_*` files, then runs triage/fix as direct subprocesses (`cursor-agent --print ... | tee file`) so their output streams live in the orchestrator pane.
+Each agent writes its output via Write tool and touches a sentinel file via Shell tool when done. Orchestrator pane polls for `.done_*` files and prints status. Triage/fix reuse Evelyn's pane (top-right) after reviewers finish.
 
 ### Cleanup
 

--- a/docs/spec/2026-04-12-review-auto.md
+++ b/docs/spec/2026-04-12-review-auto.md
@@ -137,7 +137,7 @@ cursor-agent --yolo --model MODEL "Read the prompt at {round_dir}/triage_prompt.
 
 The prompt file contains:
 ```
-You are a senior code-review triage agent. Read the 3 review output files at:
+You are a code-review triage agent. Read the 3 review output files at:
   {round_dir}/review_evelyn.md
   {round_dir}/review_vivian.md
   {round_dir}/review_stella.md
@@ -159,7 +159,7 @@ Your job:
 The fix agent runs in the same work pane after triage completes. Prompt is also written to a file `{round_dir}/fix_prompt.txt`:
 
 ```
-You are a senior engineer. Read the triaged issues at {round_dir}/triage.md.
+Read the triaged issues at {round_dir}/triage.md.
 Fix every issue listed. Do not fix anything not listed. Commit your changes
 with a clear message referencing the fixes. When done, run: touch {round_dir}/.done_fix
 ```

--- a/docs/spec/2026-04-12-review-auto.md
+++ b/docs/spec/2026-04-12-review-auto.md
@@ -2,7 +2,7 @@
 
 **Date:** 2026-04-12
 **Author:** Jason Wu
-**Status:** Draft
+**Status:** Done
 
 ## Problem
 

--- a/docs/spec/2026-04-12-review-auto.md
+++ b/docs/spec/2026-04-12-review-auto.md
@@ -1,0 +1,210 @@
+# review_auto.fish
+
+**Date:** 2026-04-12
+**Author:** Jason Wu
+**Status:** Draft
+
+## Problem
+
+The current review workflow is manual and sequential:
+
+1. Write code with Cursor CLI (`c` / `cursor-agent --yolo`)
+2. Run `review` — spawns 4 wezterm panes, each running a review agent (Evelyn, Vivian, Stella, Tiffany) against the current PR
+3. Wait for all 4 reviewers to finish
+4. Manually read each review, decide which findings are real
+5. Ask a new agent to fix the real findings
+6. Re-run `review` to verify fixes
+7. Repeat until clean
+
+Steps 3–7 are tedious babysitting. The user has to watch terminals, copy findings, and orchestrate fix/re-review cycles by hand.
+
+## Goal
+
+A single `review_auto` fish function that automates the full loop:
+
+```
+review → triage → fix → review → ... → clean
+```
+
+All agents run in visible wezterm panes so the user can watch progress in real time.
+
+## Design
+
+### High-level loop
+
+```
+┌─────────────────────────────────────┐
+│  1. REVIEW  (4 panes, parallel)     │
+│     Same as existing review.fish    │
+│     Agents write findings to files  │
+├─────────────────────────────────────┤
+│  2. WAIT                            │
+│     Poll until all review agents    │
+│     have exited (pane programs end) │
+├─────────────────────────────────────┤
+│  3. TRIAGE  (1 pane)                │
+│     A triage agent reads all        │
+│     review outputs and produces a   │
+│     consolidated list of real       │
+│     issues that need fixing         │
+├─────────────────────────────────────┤
+│  4. DECISION                        │
+│     If triage says "no real issues" │
+│     → exit loop, PR is clean        │
+├─────────────────────────────────────┤
+│  5. FIX  (1 pane)                   │
+│     A fix agent receives the        │
+│     triaged issues and applies      │
+│     fixes to the codebase           │
+├─────────────────────────────────────┤
+│  6. COMMIT                          │
+│     Fix agent commits changes       │
+│     (or user confirms)              │
+├─────────────────────────────────────┤
+│  7. GOTO 1                          │
+│     Loop back to review the new     │
+│     state of the code               │
+└─────────────────────────────────────┘
+```
+
+### Output capture
+
+Each agent writes its output to a temp file so downstream agents can read it:
+
+```
+/tmp/review_auto.<session>/
+  review_evelyn.md
+  review_vivian.md
+  review_stella.md
+  review_tiffany.md
+  triage.md          # consolidated real issues
+```
+
+`cursor-agent --print` mode writes to stdout, which we tee into these files. This also means each pane shows live output to the user.
+
+### Wezterm pane layout
+
+Fixed 5-pane layout for the entire session:
+
+```
+┌─────────────────────────────────────────────┐
+│              ORCHESTRATOR (pane 0)           │
+│  triage agent / fix agent / status output   │
+├──────────┬──────────┬──────────┬────────────┤
+│ Evelyn   │ Vivian   │ Stella   │ Tiffany    │
+│ (pane 1) │ (pane 2) │ (pane 3) │ (pane 4)   │
+└──────────┴──────────┴──────────┴────────────┘
+```
+
+- **Top row:** 1 wide pane — the orchestrator. Runs triage and fix agents. Also displays loop status (round number, phase, etc).
+- **Bottom row:** 4 equal panes — the 4 review agents. Run in parallel each round.
+
+Split order (verified with `wezterm cli split-pane`):
+1. pane_0 = `$WEZTERM_PANE` (orchestrator, top)
+2. pane_1 = `split-pane --pane-id $pane_0 --bottom --percent 70` (first reviewer, bottom-left)
+3. pane_2 = `split-pane --pane-id $pane_1 --right` (bottom splits 50/50)
+4. pane_3 = `split-pane --pane-id $pane_1 --right` (left half splits again → 25/25)
+5. pane_4 = `split-pane --pane-id $pane_2 --right` (right half splits again → 25/25)
+
+Bottom row gets 70% of vertical space since reviewers produce the most output. All panes persist across rounds — review panes are reused each cycle, orchestrator pane runs triage then fix sequentially between review rounds.
+
+### Waiting for agents to finish
+
+Two complementary mechanisms (both verified working):
+
+**Primary — sentinel files:** Each review command is chained with a `touch`:
+```fish
+cursor-agent --print ... | tee /tmp/review_auto.xxx/review_evelyn.md; touch /tmp/review_auto.xxx/.done_evelyn
+```
+The orchestrator polls for all `.done_*` files to exist. Simple, race-free, works even if the agent crashes (the touch still runs because it's `;`-chained, not `&&`-chained).
+
+**Fallback — TTY process check:** `wezterm cli list --format json` exposes `tty_name` for each pane. We can verify no `cursor-agent` process is running on a pane's TTY:
+```fish
+ps -t /dev/ttysXXX -o comm= | grep -q cursor-agent
+```
+Verified: this correctly returns true when an agent is running and false when it has exited.
+
+### Triage agent prompt
+
+```
+You are a senior code-review triage agent. You have 4 independent code reviews below.
+Your job:
+- Read all 4 reviews
+- Filter out nitpicks, style-only comments, and false positives
+- Output ONLY the issues that are real bugs, logic errors, security
+  vulnerabilities, or missing error handling
+- If there are no real issues, output exactly: NO_ISSUES_FOUND
+- Format each real issue as a structured block with file, line, description, and severity
+```
+
+### Fix agent prompt
+
+```
+You are a senior engineer. You have a list of triaged code-review issues below.
+Fix every issue listed. Do not fix anything not listed. Commit your changes
+with a clear message referencing the fixes.
+```
+
+### Max iterations
+
+Default cap of 3 iterations to prevent infinite loops. Configurable via argument.
+
+### Arguments
+
+```
+review_auto [options]
+  --max-rounds N     Max review/fix cycles (default: 3)
+  --provider NAME    openai | anthropic (default: anthropic)
+  --panes N          Number of review panes 1-4 (default: 4)
+  --dry-run          Run reviews + triage only, skip fix step
+```
+
+## Key decisions
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Output format | `--print` to file via tee | Gives visible terminal output AND machine-readable files for the next agent |
+| Triage sentinel | `NO_ISSUES_FOUND` string | Simple, grep-able exit condition |
+| Fix agent mode | `--yolo` (full write access) | Needs to edit files and commit |
+| Review agents | `--print` read-only | Same as existing review.fish, no writes needed |
+| Loop cap | 3 rounds | Prevents runaway; most real issues resolve in 1-2 rounds |
+
+## Feasibility findings
+
+Tested against `cursor-agent` CLI and `wezterm cli` on 2026-04-12. All core mechanics confirmed working.
+
+### cursor-agent --print
+
+- `--print` mode is **non-interactive**: runs the prompt, prints output to stdout, exits. This is exactly what we need for automated panes.
+- Output piping works: `cursor-agent --print -p "prompt" 2>&1 | tee /tmp/out.md` gives both visible terminal output and a file for downstream agents.
+- `--output-format` supports `text` (default), `json`, and `stream-json`. We use `text` for review panes (human-readable in the pane) and `text` for triage/fix (needs to be read by the next agent from file).
+- `--trust` flag skips workspace trust prompt in headless/print mode — **required** for automated panes that can't interactively approve.
+- `--mode ask` available for read-only review agents; `--yolo` for fix agent that needs write access.
+
+### wezterm cli
+
+- **`list --format json`** returns pane metadata including `pane_id`, `tty_name`, `title`, `is_active`. The `tty_name` field lets us check what processes are running in each pane via `ps -t <tty>`.
+- **`split-pane`** returns the new pane ID on stdout. Supports `--bottom`, `--right`, `--percent`, `--pane-id` targeting. Confirmed: splitting a pane that was already split works correctly (splits the remaining space of that pane, not the whole window).
+- **`send-text --no-paste --pane-id N`** sends raw keystrokes. Pipes and redirects in the sent text are interpreted by the pane's shell, so `cmd | tee file` works naturally.
+- **`get-text --pane-id N`** scrapes visible pane buffer. Works but scrollback is limited — tee to file is more reliable for capturing full agent output.
+- **`kill-pane --pane-id N`** available for cleanup.
+- **`wezterm` binary location:** `/Applications/WezTerm.app/Contents/MacOS/wezterm`. Not in PATH in non-wezterm shells, but inside wezterm panes it's aliased. The fish function runs inside wezterm so this is fine.
+
+### Pane lifecycle
+
+- Using `send-text` approach (same as existing `review.fish`): the pane has a persistent fish shell. After cursor-agent exits, the shell stays — the pane doesn't close. This is good: we can reuse panes across rounds.
+- Alternative `split-pane -- fish -c "cmd"` approach: pane runs one command and then the shell exits. Pane behavior on exit depends on wezterm `exit_behavior` config (default `CloseOnCleanExit`). **Not recommended** — we want persistent panes for reuse and visibility.
+
+### Confirmed approach
+
+Use `send-text` (matching existing `review.fish` pattern). Each pane has a fish shell. We send commands like:
+```
+cursor-agent --yolo --print --trust --model MODEL -p "PROMPT" 2>&1 | tee /tmp/session/review_NAME.md; touch /tmp/session/.done_NAME\r
+```
+Orchestrator pane polls for `.done_*` files, then reads the review output files to build the triage prompt.
+
+## Open questions
+
+- Should triage and fix reuse the same pane or split new ones each round?
+- Should the function auto-push after a clean round, or leave that to the user?
+- Should there be a `--notify` flag to send a macOS notification when done?

--- a/docs/spec/2026-04-12-review-auto.md
+++ b/docs/spec/2026-04-12-review-auto.md
@@ -166,7 +166,7 @@ review_auto [options]
 | Output format | `--print` to file via tee | Gives visible terminal output AND machine-readable files for the next agent |
 | Triage sentinel | `NO_ISSUES_FOUND` string | Simple, grep-able exit condition |
 | Fix agent mode | `--yolo` (full write access) | Needs to edit files and commit |
-| Review agents | `--print` read-only | Same as existing review.fish, no writes needed |
+| Review agents | `--yolo --print` | Needs tool access (gh, shell) for PR inspection via review skill |
 | Loop cap | 3 rounds | Prevents runaway; most real issues resolve in 1-2 rounds |
 
 ## Feasibility findings

--- a/docs/spec/2026-04-12-review-auto.md
+++ b/docs/spec/2026-04-12-review-auto.md
@@ -178,8 +178,8 @@ review_auto [options]
 |---|---|---|
 | Output format | `--print` to file via tee | Gives visible terminal output AND machine-readable files for the next agent |
 | Triage sentinel | `NO_ISSUES_FOUND` string | Simple, grep-able exit condition |
-| Fix agent mode | `--yolo` (full write access) | Needs to edit files and commit |
-| Review agents | `--yolo --print` | Needs tool access (gh, shell) for PR inspection via review skill |
+| Fix agent mode | `--yolo` (full write access) | Needs to edit files, run shell tools, and commit |
+| Review agents | `--yolo --print` | Without `--yolo`, agents can't run shell tools (gh cli, git, etc.) needed for PR inspection |
 | Loop cap | 3 rounds | Prevents runaway; most real issues resolve in 1-2 rounds |
 
 ## Feasibility findings

--- a/docs/spec/2026-04-12-review-auto.md
+++ b/docs/spec/2026-04-12-review-auto.md
@@ -73,14 +73,17 @@ Each agent writes its output to a temp file so downstream agents can read it:
 
 ```
 /tmp/review_auto.<session>/
-  review_evelyn.md
-  review_vivian.md
-  review_stella.md
-  review_tiffany.md
-  triage.md          # consolidated real issues
+  round_1/
+    review_evelyn.md
+    review_vivian.md
+    review_stella.md
+    review_tiffany.md
+    triage.md
+  round_2/
+    ...
 ```
 
-`cursor-agent --print` mode writes to stdout, which we tee into these files. This also means each pane shows live output to the user.
+Each round gets its own subdirectory so previous rounds are preserved for debugging. `cursor-agent --print` mode writes to stdout, which we tee into these files. This also means each pane shows live output to the user.
 
 ### Wezterm pane layout
 
@@ -96,8 +99,8 @@ Fixed 5-pane layout for the entire session:
 └──────────┴──────────┴──────────┴────────────┘
 ```
 
-- **Top row:** 1 wide pane — the orchestrator. Runs triage and fix agents. Also displays loop status (round number, phase, etc).
-- **Bottom row:** 4 equal panes — the 4 review agents. Run in parallel each round.
+- **Top row:** 1 wide pane — the orchestrator. The fish function lives here, running triage and fix agents as direct subprocesses (`cursor-agent --print ... | tee file`). Output streams live to this pane. The function blocks on each subprocess, so there's no conflict between polling and agent output.
+- **Bottom row:** 4 equal panes — the 4 review agents. Run in parallel each round via `send-text`.
 
 Split order (verified with `wezterm cli split-pane`):
 1. pane_0 = `$WEZTERM_PANE` (orchestrator, top)
@@ -114,9 +117,9 @@ Two complementary mechanisms (both verified working):
 
 **Primary — sentinel files:** Each review command is chained with a `touch`:
 ```fish
-cursor-agent --print ... | tee /tmp/review_auto.xxx/review_evelyn.md; touch /tmp/review_auto.xxx/.done_evelyn
+cursor-agent --print ... | tee /tmp/review_auto.xxx/round_1/review_evelyn.md; touch /tmp/review_auto.xxx/round_1/.done_evelyn
 ```
-The orchestrator polls for all `.done_*` files to exist. Simple, race-free, works even if the agent crashes (the touch still runs because it's `;`-chained, not `&&`-chained).
+The orchestrator polls for all `.done_*` files to exist. Simple, race-free, works even if the agent crashes (the touch still runs because it's `;`-chained, not `&&`-chained). Empty or error output is handled gracefully by the triage agent (it skips empty files).
 
 **Fallback — TTY process check:** `wezterm cli list --format json` exposes `tty_name` for each pane. We can verify no `cursor-agent` process is running on a pane's TTY:
 ```fish
@@ -126,21 +129,31 @@ Verified: this correctly returns true when an agent is running and false when it
 
 ### Triage agent prompt
 
+The triage agent runs as a direct subprocess in the orchestrator pane. It reads the review output files itself (has `--yolo` tool access) rather than receiving them inline — review outputs can be very long.
+
 ```
-You are a senior code-review triage agent. You have 4 independent code reviews below.
+You are a senior code-review triage agent. Read the 4 review output files at:
+  {round_dir}/review_evelyn.md
+  {round_dir}/review_vivian.md
+  {round_dir}/review_stella.md
+  {round_dir}/review_tiffany.md
+
 Your job:
 - Read all 4 reviews
 - Filter out nitpicks, style-only comments, and false positives
 - Output ONLY the issues that are real bugs, logic errors, security
   vulnerabilities, or missing error handling
+- If a review file is empty or contains an error, skip it
 - If there are no real issues, output exactly: NO_ISSUES_FOUND
 - Format each real issue as a structured block with file, line, description, and severity
 ```
 
 ### Fix agent prompt
 
+The fix agent also runs as a direct subprocess in the orchestrator pane. It reads the triage output file.
+
 ```
-You are a senior engineer. You have a list of triaged code-review issues below.
+You are a senior engineer. Read the triaged issues at {round_dir}/triage.md.
 Fix every issue listed. Do not fix anything not listed. Commit your changes
 with a clear message referencing the fixes.
 ```
@@ -201,10 +214,13 @@ Use `send-text` (matching existing `review.fish` pattern). Each pane has a fish 
 ```
 cursor-agent --yolo --print --trust --model MODEL -p "PROMPT" 2>&1 | tee /tmp/session/review_NAME.md; touch /tmp/session/.done_NAME\r
 ```
-Orchestrator pane polls for `.done_*` files, then reads the review output files to build the triage prompt.
+Orchestrator pane polls for `.done_*` files, then runs triage/fix as direct subprocesses (`cursor-agent --print ... | tee file`) so their output streams live in the orchestrator pane.
+
+### Cleanup
+
+When the loop exits (clean PR or max rounds hit), the 4 review panes are left open so the user can scroll through the last round's output. The orchestrator pane prints a summary (rounds completed, final status) and returns control to the shell.
 
 ## Open questions
 
-- Should triage and fix reuse the same pane or split new ones each round?
 - Should the function auto-push after a clean round, or leave that to the user?
 - Should there be a `--notify` flag to send a macOS notification when done?

--- a/fish/.config/fish/config.fish
+++ b/fish/.config/fish/config.fish
@@ -48,6 +48,7 @@ alias v="nvim"
 
 # Review fish function
 alias r="review"
+alias ra="review_auto"
 
 # OrbStack
 source ~/.orbstack/shell/init.fish 2>/dev/null || :

--- a/fish/.config/fish/functions/review.fish
+++ b/fish/.config/fish/functions/review.fish
@@ -37,7 +37,7 @@ function review
     set -l review_model gpt-5.4-high
     switch $provider
         case anthropic
-            set review_model claude-4.6-opus
+            set review_model claude-4.6-opus-high
     end
 
     set -l review_cmd "cursor-agent --yolo --model $review_model -p"

--- a/fish/.config/fish/functions/review.fish
+++ b/fish/.config/fish/functions/review.fish
@@ -41,7 +41,7 @@ function review
             set review_model claude-4.6-opus-high
     end
 
-    set -l review_cmd "cursor-agent --yolo --model $review_model -p"
+    set -l review_cmd "cursor-agent --yolo --model $review_model"
 
     # pane identities
     # 0 - top left

--- a/fish/.config/fish/functions/review.fish
+++ b/fish/.config/fish/functions/review.fish
@@ -1,6 +1,7 @@
 function review
     # Usage: review [1-4] [openai|anthropic] — args can be in any order.
-    # Default: 4 panes, anthropic (claude-4.6-opus). openai → gpt-5.4-high.
+    # Default: 4 panes, anthropic (claude-4.6-opus-high). openai → gpt-5.4-high.
+    # Uses --yolo so agents can run shell tools (gh cli, git, etc.) for PR inspection.
     set -l num_panes 4
     set -l provider anthropic
     set -l saw_panes false

--- a/fish/.config/fish/functions/review_auto.fish
+++ b/fish/.config/fish/functions/review_auto.fish
@@ -192,7 +192,7 @@ function review_auto
             end
             
             set frame_idx (math "$frame_idx % 10 + 1")
-            sleep 0.5
+            sleep 0.05
         end
         set -l elapsed (math (date +%s) - $round_start)
         set -l mins (math "floor($elapsed / 60)")

--- a/fish/.config/fish/functions/review_auto.fish
+++ b/fish/.config/fish/functions/review_auto.fish
@@ -67,9 +67,10 @@ function review_auto
         return 1
     end
 
-    set -l pr_json (gh pr view --json number,url 2>/dev/null)
+    set -l pr_json (gh pr view --json number,url,title 2>/dev/null)
     set -l pr_number (echo $pr_json | string match -r '"number":(\d+)' | tail -1)
     set -l pr_url (echo $pr_json | string match -r '"url":"([^"]+)"' | tail -1)
+    set -l pr_title (echo $pr_json | string match -r '"title":"([^"]+)"' | tail -1)
     if test -z "$pr_number"
         echo "No PR found for current branch"
         return 1
@@ -154,7 +155,11 @@ function review_auto
 
     # --- header (printed once) ---
     printf "\n\n"
-    echo " "(set_color --bold)"review_auto"(set_color normal)" "(set_color brblack)"·"(set_color normal)" PR #"(set_color cyan)$pr_number(set_color normal)
+    set -l pr_label "PR #$pr_number"
+    if test -n "$pr_title"
+        set pr_label $pr_title
+    end
+    echo " "(set_color --bold)"review_auto"(set_color normal)" "(set_color brblack)"·"(set_color normal)" "\e]8\;\;$pr_url\e\\(set_color cyan)$pr_label(set_color normal)\e]8\;\;\e\\
     echo " "(set_color brblack)"$provider · $num_panes reviewers"(set_color normal)
     echo ""
 

--- a/fish/.config/fish/functions/review_auto.fish
+++ b/fish/.config/fish/functions/review_auto.fish
@@ -185,7 +185,7 @@ function review_auto
             end
 
             set frame_idx (math "$frame_idx % 10 + 1")
-            sleep 0.05
+            sleep 0.05 # ~20 FPS for smooth spinner animation
         end
         set -l elapsed (math (date +%s) - $round_start)
         set -l mins (math "floor($elapsed / 60)")
@@ -193,7 +193,6 @@ function review_auto
         set -l time_str (printf "%d:%02d" $mins $secs)
         printf "\r                                                           \r"
         echo "   "(set_color white)"●"(set_color normal)"  review  $status_line"(set_color brblack)"$time_str"(set_color normal)
-        echo ""
 
         # kill reviewer panes and create fresh pane for triage/fix
         for pane in $pane_ids
@@ -210,9 +209,9 @@ function review_auto
         set -l file_list (string join ", " $review_files)
 
         set -l triage_sentinel "$round_dir/.done_triage"
-        set -l triage_prompt "You are a senior code-review triage agent. Read the review output files at: $file_list. Read all review files using the Read tool. Filter out nitpicks, style-only comments, and false positives. Identify ONLY real bugs, logic errors, security vulnerabilities, or missing error handling. If a review file is empty or contains an error, skip it. Write your verdict to $round_dir/triage.md. If there are NO real issues: write ONLY the text NO_ISSUES_FOUND (nothing else, just that one line). If there ARE real issues: write each issue with file path, line number, severity (critical/high/medium), and description. Do NOT include the string NO_ISSUES_FOUND anywhere."
+        set -l triage_prompt "You are a senior code-review triage agent. Read the review output files at: $file_list. Read all review files using the Read tool. Filter out nitpicks, style-only comments, and false positives. Identify ONLY real bugs, logic errors, security vulnerabilities, or missing error handling. If a review file is empty or contains an error, skip it. Write your verdict to $round_dir/triage.md. If there are NO real issues: write ONLY the text NO_ISSUES_FOUND (nothing else, just that one line). If there ARE real issues: write each issue with file path, line number, severity (critical/high/medium), and description. Do NOT include the string NO_ISSUES_FOUND anywhere. When completely done, run this shell command: touch $triage_sentinel"
 
-        set -l triage_cmd "cursor-agent --yolo --model $triage_model \"$triage_prompt\"; touch $triage_sentinel"
+        set -l triage_cmd "cursor-agent --yolo --model $triage_model \"$triage_prompt\""
         printf '%s\r' "$triage_cmd" | wezterm cli send-text --no-paste --pane-id $work_pane
 
         set frame_idx 1
@@ -223,7 +222,7 @@ function review_auto
             set -l time_str (printf "%d:%02d" $mins $secs)
             printf "\r   %s%s%s  triage  %s%s%s" $dim $spinner_frames[$frame_idx] $reset $dim $time_str $reset
             set frame_idx (math "$frame_idx % 10 + 1")
-            sleep 0.05
+            sleep 0.05 # ~20 FPS for smooth spinner animation
         end
         set -l elapsed (math (date +%s) - $round_start)
         set -l mins (math "floor($elapsed / 60)")
@@ -231,7 +230,6 @@ function review_auto
         set -l time_str (printf "%d:%02d" $mins $secs)
         printf "\r                                                           \r"
         echo "   "(set_color white)"●"(set_color normal)"  triage  "(set_color brblack)"$time_str"(set_color normal)
-        echo ""
 
         # check triage result - must be on its own line to avoid false matches
         if grep -qx NO_ISSUES_FOUND $round_dir/triage.md 2>/dev/null
@@ -252,9 +250,9 @@ function review_auto
         set work_pane (wezterm cli split-pane --pane-id $pane_0 --right)
 
         set -l fix_sentinel "$round_dir/.done_fix"
-        set -l fix_prompt "You are a senior engineer. Read the triaged code-review issues at $round_dir/triage.md using the Read tool. Fix every issue listed. Do not fix anything not listed. After fixing, commit your changes with a clear message referencing what was fixed, then push to the remote branch with git push."
+        set -l fix_prompt "You are a senior engineer. Read the triaged code-review issues at $round_dir/triage.md using the Read tool. Fix every issue listed. Do not fix anything not listed. After fixing, commit your changes with a clear message referencing what was fixed, then push to the remote branch with git push. When completely done, run this shell command: touch $fix_sentinel"
 
-        set -l fix_cmd "cursor-agent --yolo --model $fix_model \"$fix_prompt\"; touch $fix_sentinel"
+        set -l fix_cmd "cursor-agent --yolo --model $fix_model \"$fix_prompt\""
         printf '%s\r' "$fix_cmd" | wezterm cli send-text --no-paste --pane-id $work_pane
 
         set frame_idx 1
@@ -265,7 +263,7 @@ function review_auto
             set -l time_str (printf "%d:%02d" $mins $secs)
             printf "\r   %s%s%s  fix  %s%s%s" $dim $spinner_frames[$frame_idx] $reset $dim $time_str $reset
             set frame_idx (math "$frame_idx % 10 + 1")
-            sleep 0.05
+            sleep 0.05 # ~20 FPS for smooth spinner animation
         end
         set -l elapsed (math (date +%s) - $round_start)
         set -l mins (math "floor($elapsed / 60)")

--- a/fish/.config/fish/functions/review_auto.fish
+++ b/fish/.config/fish/functions/review_auto.fish
@@ -90,7 +90,7 @@ function review_auto
     end
 
     set -l session_dir (mktemp -d /tmp/review_auto.XXXXXX)
-    set -l review_cmd "cursor-agent --yolo --model $review_model"
+    set -l review_cmd "cursor-agent --yolo --model $review_model -p"
 
     # reviewer identities and prompts
     set -l names Evelyn Vivian Stella
@@ -119,6 +119,7 @@ function review_auto
     set -l pane_bottom (wezterm cli split-pane --pane-id $pane_0 --bottom)
     if test -z "$pane_bottom"
         echo "Failed to create bottom pane (split-pane returned empty ID)"
+        rm -rf $session_dir
         return 1
     end
     # Step 2: split top row to create Evelyn (top-right)
@@ -126,6 +127,7 @@ function review_auto
     if test -z "$pane_evelyn"
         echo "Failed to create Evelyn pane (split-pane returned empty ID)"
         wezterm cli kill-pane --pane-id $pane_bottom &>/dev/null
+        rm -rf $session_dir
         return 1
     end
     # Step 3: split bottom row to create Stella (bottom-right)

--- a/fish/.config/fish/functions/review_auto.fish
+++ b/fish/.config/fish/functions/review_auto.fish
@@ -248,12 +248,12 @@ function review_auto
                 end
             end
 
-            set -l elapsed (math (date +%s) - $round_start)
-            set -l mins (math "floor($elapsed / 60)")
-            set -l secs (math "$elapsed % 60")
-            set -l time_str (printf "%d:%02d" $mins $secs)
+            set -l phase_el (math (date +%s) - $round_start)
+            set -l phase_m (math "floor($phase_el / 60)")
+            set -l phase_s (math "$phase_el % 60")
+            set -l phase_ts (printf "%d:%02d" $phase_m $phase_s)
             set -l dots (printf "%-4s" $dot_frames[$frame_idx])
-            printf "\r %s•%s Reviewing%s%s(%s/%s)%s  %s %s%s%s" (set_color $dot_colors[$frame_idx]) $reset "$dots" $dim $round $max_rounds $reset "$status_line" $dim $time_str $reset
+            printf "\r %s•%s Reviewing%s%s(%s/%s)%s  %s %s%s%s" (set_color $dot_colors[$frame_idx]) $reset "$dots" $dim $round $max_rounds $reset "$status_line" $dim $phase_ts $reset
 
             if test $done_count -ge $num_panes
                 break
@@ -271,10 +271,10 @@ function review_auto
             set frame_idx (math "$frame_idx % 3 + 1")
             sleep 0.15
         end
-        set -l elapsed (math (date +%s) - $round_start)
-        set -l mins (math "floor($elapsed / 60)")
-        set -l secs (math "$elapsed % 60")
-        set -l time_str (printf "%d:%02d" $mins $secs)
+        set -l review_dur (math (date +%s) - $round_start)
+        set -l review_dur_m (math "floor($review_dur / 60)")
+        set -l review_dur_s (math "$review_dur % 60")
+        set -l review_dur_str (printf "%d:%02d" $review_dur_m $review_dur_s)
 
         # kill reviewer panes and create fresh work pane before printing final status
         # (pane resize happens here, before any output)
@@ -288,7 +288,7 @@ function review_auto
         end
 
         printf "\r                                                           \r"
-        echo " "(set_color green)"✔"(set_color normal)" Reviewed "(set_color brblack)"($round/$max_rounds)"(set_color normal)"  $status_line"(set_color brblack)"$time_str"(set_color normal)
+        echo " "(set_color green)"✔"(set_color normal)" Reviewed "(set_color brblack)"($round/$max_rounds)"(set_color normal)"  $status_line"(set_color brblack)"$review_dur_str"(set_color normal)
 
         # --- triage phase ---
         set -l review_files
@@ -309,14 +309,18 @@ function review_auto
         set -l triage_start (date +%s)
         set frame_idx 1
         while not test -f $triage_sentinel
-            set -l elapsed (math (date +%s) - $round_start)
-            set -l mins (math "floor($elapsed / 60)")
-            set -l secs (math "$elapsed % 60")
-            set -l time_str (printf "%d:%02d" $mins $secs)
+            set -l phase_el (math (date +%s) - $triage_start)
+            set -l phase_m (math "floor($phase_el / 60)")
+            set -l phase_s (math "$phase_el % 60")
+            set -l phase_ts (printf "%d:%02d" $phase_m $phase_s)
+            set -l total_el (math (date +%s) - $round_start)
+            set -l total_m (math "floor($total_el / 60)")
+            set -l total_s (math "$total_el % 60")
+            set -l total_ts (printf "%d:%02d" $total_m $total_s)
             set -l dots (printf "%-4s" $dot_frames[$frame_idx])
-            printf "\r %s•%s Triaging%s %s%s%s" (set_color $dot_colors[$frame_idx]) $reset "$dots" $dim $time_str $reset
+            printf "\r %s•%s Triaging%s %s%s%s  %s%s%s" (set_color $dot_colors[$frame_idx]) $reset "$dots" $dim $phase_ts $reset $dim $total_ts $reset
 
-            set -l phase_elapsed (math (date +%s) - $triage_start)
+            set -l phase_elapsed $phase_el
             if test $phase_elapsed -ge $phase_timeout
                 printf "\r                                                           \r"
                 echo " "(set_color red)"✗"(set_color normal)"  Triage phase timed out after $phase_timeout seconds in round $round"
@@ -327,10 +331,10 @@ function review_auto
             set frame_idx (math "$frame_idx % 3 + 1")
             sleep 0.15
         end
-        set -l elapsed (math (date +%s) - $round_start)
-        set -l mins (math "floor($elapsed / 60)")
-        set -l secs (math "$elapsed % 60")
-        set -l time_str (printf "%d:%02d" $mins $secs)
+        set -l triage_dur (math (date +%s) - $triage_start)
+        set -l triage_dur_m (math "floor($triage_dur / 60)")
+        set -l triage_dur_s (math "$triage_dur % 60")
+        set -l triage_dur_str (printf "%d:%02d" $triage_dur_m $triage_dur_s)
 
         # kill triage pane and create fresh one before printing
         # (pane resize happens here, before any output)
@@ -342,7 +346,7 @@ function review_auto
         end
 
         printf "\r                                                           \r"
-        echo " "(set_color green)"✔"(set_color normal)" Triaged  "(set_color brblack)"$time_str"(set_color normal)
+        echo " "(set_color green)"✔"(set_color normal)" Triaged  "(set_color brblack)"$triage_dur_str"(set_color normal)
 
         # check triage result - compare trimmed entire file to exact string
         set -l _triage_content (string trim (cat $round_dir/triage.md 2>/dev/null))
@@ -377,14 +381,18 @@ function review_auto
         set -l fix_start (date +%s)
         set frame_idx 1
         while not test -f $fix_sentinel
-            set -l elapsed (math (date +%s) - $round_start)
-            set -l mins (math "floor($elapsed / 60)")
-            set -l secs (math "$elapsed % 60")
-            set -l time_str (printf "%d:%02d" $mins $secs)
+            set -l phase_el (math (date +%s) - $fix_start)
+            set -l phase_m (math "floor($phase_el / 60)")
+            set -l phase_s (math "$phase_el % 60")
+            set -l phase_ts (printf "%d:%02d" $phase_m $phase_s)
+            set -l total_el (math (date +%s) - $round_start)
+            set -l total_m (math "floor($total_el / 60)")
+            set -l total_s (math "$total_el % 60")
+            set -l total_ts (printf "%d:%02d" $total_m $total_s)
             set -l dots (printf "%-4s" $dot_frames[$frame_idx])
-            printf "\r %s•%s Fixing%s %s%s%s" (set_color $dot_colors[$frame_idx]) $reset "$dots" $dim $time_str $reset
+            printf "\r %s•%s Fixing%s %s%s%s  %s%s%s" (set_color $dot_colors[$frame_idx]) $reset "$dots" $dim $phase_ts $reset $dim $total_ts $reset
 
-            set -l phase_elapsed (math (date +%s) - $fix_start)
+            set -l phase_elapsed $phase_el
             if test $phase_elapsed -ge $phase_timeout
                 printf "\r                                                           \r"
                 echo " "(set_color red)"✗"(set_color normal)"  Fix phase timed out after $phase_timeout seconds in round $round"
@@ -395,12 +403,12 @@ function review_auto
             set frame_idx (math "$frame_idx % 3 + 1")
             sleep 0.15
         end
-        set -l elapsed (math (date +%s) - $round_start)
-        set -l mins (math "floor($elapsed / 60)")
-        set -l secs (math "$elapsed % 60")
-        set -l time_str (printf "%d:%02d" $mins $secs)
+        set -l fix_dur (math (date +%s) - $fix_start)
+        set -l fix_dur_m (math "floor($fix_dur / 60)")
+        set -l fix_dur_s (math "$fix_dur % 60")
+        set -l fix_dur_str (printf "%d:%02d" $fix_dur_m $fix_dur_s)
         printf "\r                                                           \r"
-        echo " "(set_color green)"✔"(set_color normal)" Fixed  "(set_color brblack)"$time_str"(set_color normal)
+        echo " "(set_color green)"✔"(set_color normal)" Fixed  "(set_color brblack)"$fix_dur_str"(set_color normal)
 
         # kill work pane before next round
         wezterm cli kill-pane --pane-id $work_pane &>/dev/null

--- a/fish/.config/fish/functions/review_auto.fish
+++ b/fish/.config/fish/functions/review_auto.fish
@@ -163,7 +163,7 @@ function review_auto
                 end
             end
             
-            printf "\r     $dim$spinner_frames[$frame_idx]$reset  $status_line"
+            printf "\r  $dim$spinner_frames[$frame_idx]$reset  $status_line"
             
             if test $done_count -ge $num_panes
                 break
@@ -204,7 +204,7 @@ Your job:
 
         set frame_idx 1
         while not test -f $triage_sentinel
-            printf "\r     $dim$spinner_frames[$frame_idx]$reset  triaging..."
+            printf "\r  $dim$spinner_frames[$frame_idx]$reset  triaging..."
             set frame_idx (math "$frame_idx % 10 + 1")
             sleep 0.05
         end
@@ -213,25 +213,15 @@ Your job:
 
         # check triage result
         if grep -q "NO_ISSUES_FOUND" $round_dir/triage.md
-            echo "$dim───────────────────────────────────────────────────$reset"
             echo ""
-            echo "  $green●$reset  $bold clean$reset"
-            echo ""
-            echo "     $dim no issues found in round $round$reset"
-            echo ""
-            echo "$dim───────────────────────────────────────────────────$reset"
+            echo "  $green●$reset  $bold clean$reset $dim— no issues found$reset"
             echo ""
             return 0
         end
 
         if test "$dry_run" = true
-            echo "$dim───────────────────────────────────────────────────$reset"
             echo ""
-            echo "  $yellow●$reset  $bold dry run$reset"
-            echo ""
-            echo "     $dim issues found, skipping fix$reset"
-            echo ""
-            echo "$dim───────────────────────────────────────────────────$reset"
+            echo "  $yellow●$reset  $bold dry run$reset $dim— issues found, skipping fix$reset"
             echo ""
             return 0
         end
@@ -248,7 +238,7 @@ Your job:
 
         set frame_idx 1
         while not test -f $fix_sentinel
-            printf "\r     $dim$spinner_frames[$frame_idx]$reset  fixing..."
+            printf "\r  $dim$spinner_frames[$frame_idx]$reset  fixing..."
             set frame_idx (math "$frame_idx % 10 + 1")
             sleep 0.05
         end
@@ -258,13 +248,8 @@ Your job:
         set round (math $round + 1)
     end
 
-    echo "$dim───────────────────────────────────────────────────$reset"
     echo ""
-    echo "  $red●$reset  $bold max rounds$reset"
-    echo ""
-    echo "     $dim completed $max_rounds rounds, review manually$reset"
-    echo ""
-    echo "$dim───────────────────────────────────────────────────$reset"
+    echo "  $red●$reset  $bold max rounds$reset $dim— review manually$reset"
     echo ""
     return 1
 end

--- a/fish/.config/fish/functions/review_auto.fish
+++ b/fish/.config/fish/functions/review_auto.fish
@@ -72,8 +72,8 @@ function review_auto
     set -l red (set_color red)
 
     set -l white (set_color white)
-    
-    printf "\n\n"
+
+    printf "\n"
     set -l header1 "   "(set_color --bold)"review_auto"(set_color normal)"  "(set_color brblack)"·"(set_color normal)"  PR #"(set_color cyan)$pr_number(set_color normal)
     set -l header2 "   "(set_color brblack)$provider" · "$num_panes" reviewers · "$max_rounds" rounds max"(set_color normal)
     echo $header1
@@ -156,13 +156,13 @@ function review_auto
                     set status_line "$status_line$dim$name$reset  "
                 end
             end
-            
+
             printf "\r   %s%s%s  %s" $dim $spinner_frames[$frame_idx] $reset "$status_line"
-            
+
             if test $done_count -ge $num_panes
                 break
             end
-            
+
             set frame_idx (math "$frame_idx % 10 + 1")
             sleep 0.05
         end
@@ -202,7 +202,7 @@ Your job:
         echo ""
 
         # check triage result
-        if grep -q "NO_ISSUES_FOUND" $round_dir/triage.md
+        if grep -q NO_ISSUES_FOUND $round_dir/triage.md
             echo ""
             echo "   "(set_color green)"●"(set_color normal)"  "(set_color --bold)"clean"(set_color normal)" "(set_color brblack)"— no issues found"(set_color normal)
             echo ""

--- a/fish/.config/fish/functions/review_auto.fish
+++ b/fish/.config/fish/functions/review_auto.fish
@@ -51,7 +51,7 @@ function review_auto
     end
 
     set -l session_dir (mktemp -d /tmp/review_auto.XXXXXX)
-    set -l review_cmd "cursor-agent --yolo --print --trust --model $review_model -p"
+    set -l review_cmd "cursor-agent --yolo --model $review_model"
 
     # reviewer identities and prompts
     set -l names Evelyn Vivian Stella Tiffany
@@ -110,18 +110,23 @@ function review_auto
         echo "  ROUND $round / $max_rounds — REVIEW PHASE"
         echo "═══════════════════════════════════════════════"
 
-        # clean sentinel files
+        # clean sentinel files and kill any lingering agents from previous round
         for j in (seq $num_panes)
             set -l name (string lower $names[$j])
             rm -f $round_dir/.done_$name
+            if test $round -gt 1
+                printf '\x03' | wezterm cli send-text --no-paste --pane-id $pane_ids[$j]
+                sleep 1
+            end
         end
 
         # dispatch review agents to panes
         for j in (seq $num_panes)
             set -l name (string lower $names[$j])
             set -l outfile "$round_dir/review_$name.md"
-            set -l prompt "$base_prompts[$j] IMPORTANT: When done, write your complete review to $outfile using the Write tool."
-            set -l cmd "$review_cmd \"$prompt\"; touch $round_dir/.done_$name"
+            set -l sentinel "$round_dir/.done_$name"
+            set -l prompt "$base_prompts[$j] IMPORTANT: When done, write your complete review to $outfile using the Write tool. Then run this shell command: touch $sentinel"
+            set -l cmd "$review_cmd \"$prompt\""
             printf '%s\r' "$cmd" | wezterm cli send-text --no-paste --pane-id $pane_ids[$j]
         end
 

--- a/fish/.config/fish/functions/review_auto.fish
+++ b/fish/.config/fish/functions/review_auto.fish
@@ -74,8 +74,8 @@ function review_auto
     set -l white (set_color white)
     
     echo ""
-    echo "  $bold review_auto$reset  $dim·$reset  PR #$cyan$pr_number$reset"
-    echo "  $dim$provider · $num_panes reviewers · $max_rounds rounds max$reset"
+    echo "   $bold review_auto$reset  $dim·$reset  PR #$cyan$pr_number$reset"
+    echo "   $dim$provider · $num_panes reviewers · $max_rounds rounds max$reset"
     echo ""
 
     # --- split panes: 4 quadrants (orchestrator + 3 reviewers) ---
@@ -114,9 +114,9 @@ function review_auto
         mkdir -p $round_dir
 
         echo ""
-        echo "  $bold round $round$reset$dim / $max_rounds$reset"
+        echo "   $bold round $round$reset$dim / $max_rounds$reset"
         echo ""
-        echo "  $white●$reset  review"
+        echo "   $white●$reset  review"
 
         # clean sentinel files and kill any lingering agents from previous round
         for j in (seq $num_panes)
@@ -155,7 +155,7 @@ function review_auto
                 end
             end
             
-            printf "\r  $dim$spinner_frames[$frame_idx]$reset  $status_line"
+            printf "\r   $dim$spinner_frames[$frame_idx]$reset  $status_line"
             
             if test $done_count -ge $num_panes
                 break
@@ -166,7 +166,7 @@ function review_auto
         end
         echo ""
         echo ""
-        echo "  $white●$reset  triage"
+        echo "   $white●$reset  triage"
 
         set -l review_files
         for j in (seq $num_panes)
@@ -193,7 +193,7 @@ Your job:
 
         set frame_idx 1
         while not test -f $triage_sentinel
-            printf "\r  $dim$spinner_frames[$frame_idx]$reset  triaging..."
+            printf "\r   $dim$spinner_frames[$frame_idx]$reset  triaging..."
             set frame_idx (math "$frame_idx % 10 + 1")
             sleep 0.05
         end
@@ -202,21 +202,21 @@ Your job:
         # check triage result
         if grep -q "NO_ISSUES_FOUND" $round_dir/triage.md
             echo ""
-            echo "  $green●$reset  $bold clean$reset $dim— no issues found$reset"
+            echo "   $green●$reset  $bold clean$reset $dim— no issues found$reset"
             echo ""
             return 0
         end
 
         if test "$dry_run" = true
             echo ""
-            echo "  $yellow●$reset  $bold dry run$reset $dim— issues found, skipping fix$reset"
+            echo "   $yellow●$reset  $bold dry run$reset $dim— issues found, skipping fix$reset"
             echo ""
             return 0
         end
 
         # --- fix phase (runs in Evelyn's pane) ---
         echo ""
-        echo "  $white●$reset  fix"
+        echo "   $white●$reset  fix"
 
         set -l fix_sentinel "$round_dir/.done_fix"
         set -l fix_prompt "You are a senior engineer. Read the triaged code-review issues at $round_dir/triage.md using the Read tool. Fix every issue listed. Do not fix anything not listed. After fixing, commit your changes with a clear message referencing what was fixed. When completely done, run: touch $fix_sentinel"
@@ -226,7 +226,7 @@ Your job:
 
         set frame_idx 1
         while not test -f $fix_sentinel
-            printf "\r  $dim$spinner_frames[$frame_idx]$reset  fixing..."
+            printf "\r   $dim$spinner_frames[$frame_idx]$reset  fixing..."
             set frame_idx (math "$frame_idx % 10 + 1")
             sleep 0.05
         end
@@ -236,7 +236,7 @@ Your job:
     end
 
     echo ""
-    echo "  $red●$reset  $bold max rounds$reset $dim— review manually$reset"
+    echo "   $red●$reset  $bold max rounds$reset $dim— review manually$reset"
     echo ""
     return 1
 end

--- a/fish/.config/fish/functions/review_auto.fish
+++ b/fish/.config/fish/functions/review_auto.fish
@@ -339,7 +339,7 @@ function review_auto
         set -l _triage_content (string trim (cat $round_dir/triage.md 2>/dev/null))
         if test "$_triage_content" = NO_ISSUES_FOUND
             wezterm cli kill-pane --pane-id $work_pane &>/dev/null
-            echo " "(set_color green)"●"(set_color normal)"  "(set_color --bold)"clean"(set_color normal)" "(set_color brblack)"— no issues found"(set_color normal)
+            echo " "(set_color green)"✔"(set_color normal)" No issues found"
             set -l total_dur (math (date +%s) - $session_start)
             set -l total_dur_m (math "floor($total_dur / 60)")
             set -l total_dur_s (math "$total_dur % 60")
@@ -351,7 +351,7 @@ function review_auto
 
         if test "$dry_run" = true
             wezterm cli kill-pane --pane-id $work_pane &>/dev/null
-            echo " "(set_color yellow)"●"(set_color normal)"  "(set_color --bold)"dry run"(set_color normal)" "(set_color brblack)"— issues found, skipping fix"(set_color normal)
+            echo " "(set_color yellow)"⚠"(set_color normal)" Issues found "(set_color brblack)"(dry run)"(set_color normal)
             set -l total_dur (math (date +%s) - $session_start)
             set -l total_dur_m (math "floor($total_dur / 60)")
             set -l total_dur_s (math "$total_dur % 60")
@@ -402,7 +402,7 @@ function review_auto
     end
 
     echo ""
-    echo " "(set_color red)"●"(set_color normal)"  "(set_color --bold)"max rounds"(set_color normal)" "(set_color brblack)"— review manually"(set_color normal)
+    echo " "(set_color red)"✗"(set_color normal)" Max rounds reached"
     set -l total_dur (math (date +%s) - $session_start)
     set -l total_dur_m (math "floor($total_dur / 60)")
     set -l total_dur_s (math "$total_dur % 60")

--- a/fish/.config/fish/functions/review_auto.fish
+++ b/fish/.config/fish/functions/review_auto.fish
@@ -71,9 +71,18 @@ function review_auto
     set -l magenta (set_color magenta)
     set -l red (set_color red)
 
+    set -l white (set_color white)
+    
     echo ""
-    echo "  $bold review_auto$reset $dim·$reset PR #$cyan$pr_number$reset $dim·$reset $provider $dim·$reset $num_panes reviewers $dim·$reset $max_rounds rounds"
+    echo "$dim───────────────────────────────────────────────────$reset"
     echo ""
+    echo "  $bold review_auto$reset  $dim·$reset  PR #$cyan$pr_number$reset"
+    echo ""
+    echo "  $dim provider$reset   $provider"
+    echo "  $dim reviewers$reset  $num_panes"
+    echo "  $dim rounds$reset     $max_rounds max"
+    echo ""
+    echo "$dim───────────────────────────────────────────────────$reset"
 
     # --- split panes: 4 quadrants (orchestrator + 3 reviewers) ---
     # Layout:
@@ -111,7 +120,11 @@ function review_auto
         mkdir -p $round_dir
 
         echo ""
-        echo "  $magenta$bold round $round$reset$dim/$max_rounds$reset  $dim reviewing$reset"
+        echo ""
+        echo "  $bold round $round$reset$dim / $max_rounds$reset"
+        echo ""
+        echo "  $white●$reset  review"
+        echo ""
 
         # clean sentinel files and kill any lingering agents from previous round
         for j in (seq $num_panes)
@@ -150,7 +163,7 @@ function review_auto
                 end
             end
             
-            printf "\r  $dim$spinner_frames[$frame_idx]$reset $status_line"
+            printf "\r     $dim$spinner_frames[$frame_idx]$reset  $status_line"
             
             if test $done_count -ge $num_panes
                 break
@@ -159,10 +172,12 @@ function review_auto
             set frame_idx (math "$frame_idx % 10 + 1")
             sleep 0.05
         end
-        printf "\n"
+        echo ""
+        echo ""
 
         # --- triage phase (runs in Evelyn's pane) ---
-        echo "  $cyan$bold round $round$reset$dim/$max_rounds$reset  $dim triaging$reset"
+        echo "  $white●$reset  triage"
+        echo ""
 
         set -l review_files
         for j in (seq $num_panes)
@@ -189,29 +204,41 @@ Your job:
 
         set frame_idx 1
         while not test -f $triage_sentinel
-            printf "\r  $dim$spinner_frames[$frame_idx]$reset  triaging..."
+            printf "\r     $dim$spinner_frames[$frame_idx]$reset  triaging..."
             set frame_idx (math "$frame_idx % 10 + 1")
             sleep 0.05
         end
-        printf "\n"
+        echo ""
+        echo ""
 
         # check triage result
         if grep -q "NO_ISSUES_FOUND" $round_dir/triage.md
+            echo "$dim───────────────────────────────────────────────────$reset"
             echo ""
-            echo "  $green$bold clean$reset $dim— no issues found$reset"
+            echo "  $green●$reset  $bold clean$reset"
+            echo ""
+            echo "     $dim no issues found in round $round$reset"
+            echo ""
+            echo "$dim───────────────────────────────────────────────────$reset"
             echo ""
             return 0
         end
 
         if test "$dry_run" = true
+            echo "$dim───────────────────────────────────────────────────$reset"
             echo ""
-            echo "  $yellow$bold dry run$reset $dim— issues found, skipping fix$reset"
+            echo "  $yellow●$reset  $bold dry run$reset"
+            echo ""
+            echo "     $dim issues found, skipping fix$reset"
+            echo ""
+            echo "$dim───────────────────────────────────────────────────$reset"
             echo ""
             return 0
         end
 
         # --- fix phase (runs in Evelyn's pane) ---
-        echo "  $yellow$bold round $round$reset$dim/$max_rounds$reset  $dim fixing$reset"
+        echo "  $white●$reset  fix"
+        echo ""
 
         set -l fix_sentinel "$round_dir/.done_fix"
         set -l fix_prompt "You are a senior engineer. Read the triaged code-review issues at $round_dir/triage.md using the Read tool. Fix every issue listed. Do not fix anything not listed. After fixing, commit your changes with a clear message referencing what was fixed. When completely done, run: touch $fix_sentinel"
@@ -221,17 +248,23 @@ Your job:
 
         set frame_idx 1
         while not test -f $fix_sentinel
-            printf "\r  $dim$spinner_frames[$frame_idx]$reset  fixing..."
+            printf "\r     $dim$spinner_frames[$frame_idx]$reset  fixing..."
             set frame_idx (math "$frame_idx % 10 + 1")
             sleep 0.05
         end
-        printf "\n"
+        echo ""
+        echo ""
 
         set round (math $round + 1)
     end
 
+    echo "$dim───────────────────────────────────────────────────$reset"
     echo ""
-    echo "  $red$bold max rounds$reset $dim— review manually$reset"
+    echo "  $red●$reset  $bold max rounds$reset"
+    echo ""
+    echo "     $dim completed $max_rounds rounds, review manually$reset"
+    echo ""
+    echo "$dim───────────────────────────────────────────────────$reset"
     echo ""
     return 1
 end

--- a/fish/.config/fish/functions/review_auto.fish
+++ b/fish/.config/fish/functions/review_auto.fish
@@ -116,7 +116,7 @@ function review_auto
         mkdir -p $round_dir
 
         echo ""
-        echo "   "(set_color --bold)"round $round"(set_color normal)(set_color brblack)" / $max_rounds"(set_color normal)
+        echo "   "(set_color brblack)"round $round / $max_rounds"(set_color normal)
         echo ""
         echo "   "(set_color white)"●"(set_color normal)"  review"
 

--- a/fish/.config/fish/functions/review_auto.fish
+++ b/fish/.config/fish/functions/review_auto.fish
@@ -96,18 +96,30 @@ function review_auto
     # ├─────────────────────┼─────────────────────┤
     # │     Vivian          │      Stella         │
     # └─────────────────────┴─────────────────────┘
+    # Split order matters: bottom first, then split each row
     set -l pane_0 $WEZTERM_PANE
     set -l pane_ids
 
-    # Create only the panes we need
-    if test $num_panes -ge 1
-        set -a pane_ids (wezterm cli split-pane --pane-id $pane_0 --right)
+    # Step 1: split horizontally to create bottom row
+    set -l pane_bottom (wezterm cli split-pane --pane-id $pane_0 --bottom)
+    # Step 2: split top row to create Evelyn (top-right)
+    set -l pane_evelyn (wezterm cli split-pane --pane-id $pane_0 --right)
+    # Step 3: split bottom row to create Stella (bottom-right)
+    set -l pane_stella (wezterm cli split-pane --pane-id $pane_bottom --right)
+    # pane_bottom is now Vivian (bottom-left)
+    set -l pane_vivian $pane_bottom
+
+    # pane_ids order: Evelyn, Vivian, Stella
+    set pane_ids $pane_evelyn $pane_vivian $pane_stella
+
+    # Kill unused panes if num_panes < 3
+    if test $num_panes -lt 3
+        wezterm cli kill-pane --pane-id $pane_stella 2>/dev/null
+        set pane_ids $pane_evelyn $pane_vivian
     end
-    if test $num_panes -ge 2
-        set -a pane_ids (wezterm cli split-pane --pane-id $pane_0 --bottom)
-    end
-    if test $num_panes -ge 3
-        set -a pane_ids (wezterm cli split-pane --pane-id $pane_ids[2] --right)
+    if test $num_panes -lt 2
+        wezterm cli kill-pane --pane-id $pane_vivian 2>/dev/null
+        set pane_ids $pane_evelyn
     end
 
     # --- main loop ---

--- a/fish/.config/fish/functions/review_auto.fish
+++ b/fish/.config/fish/functions/review_auto.fish
@@ -124,7 +124,6 @@ function review_auto
         printf "\n\n"
         echo " "(set_color --bold)"review_auto"(set_color normal)"  "(set_color brblack)"·"(set_color normal)"  PR #"(set_color cyan)$pr_number(set_color normal)
         echo " "(set_color brblack)"$provider · $num_panes reviewers · round $round/$max_rounds"(set_color normal)
-        echo ""
         set -l round_start (date +%s)
 
         # On round 2+, recreate reviewer panes (they were killed after the previous review phase)

--- a/fish/.config/fish/functions/review_auto.fish
+++ b/fish/.config/fish/functions/review_auto.fish
@@ -118,7 +118,8 @@ function review_auto
         echo ""
         echo "   "(set_color brblack)"round $round / $max_rounds"(set_color normal)
         echo ""
-        echo "   "(set_color white)"●"(set_color normal)"  review"
+
+        set -l round_start (date +%s)
 
         # clean sentinel files and kill any lingering agents from previous round
         for j in (seq $num_panes)
@@ -156,19 +157,27 @@ function review_auto
                     set status_line "$status_line$dim$name$reset  "
                 end
             end
-
-            printf "\r   %s%s%s  %s" $dim $spinner_frames[$frame_idx] $reset "$status_line"
-
+            
+            set -l elapsed (math (date +%s) - $round_start)
+            set -l mins (math "floor($elapsed / 60)")
+            set -l secs (math "$elapsed % 60")
+            set -l time_str (printf "%d:%02d" $mins $secs)
+            printf "\r   %s%s%s  review  %s %s%s%s" $dim $spinner_frames[$frame_idx] $reset "$status_line" $dim $time_str $reset
+            
             if test $done_count -ge $num_panes
                 break
             end
-
+            
             set frame_idx (math "$frame_idx % 10 + 1")
             sleep 0.05
         end
+        set -l elapsed (math (date +%s) - $round_start)
+        set -l mins (math "floor($elapsed / 60)")
+        set -l secs (math "$elapsed % 60")
+        set -l time_str (printf "%d:%02d" $mins $secs)
+        printf "\r                                                           \r"
+        echo "   "(set_color white)"●"(set_color normal)"  review  $status_line"(set_color brblack)"$time_str"(set_color normal)
         echo ""
-        echo ""
-        echo "   "(set_color white)"●"(set_color normal)"  triage"
 
         set -l review_files
         for j in (seq $num_panes)
@@ -195,11 +204,20 @@ Your job:
 
         set frame_idx 1
         while not test -f $triage_sentinel
-            printf "\r   $dim$spinner_frames[$frame_idx]$reset  triaging..."
+            set -l elapsed (math (date +%s) - $round_start)
+            set -l mins (math "floor($elapsed / 60)")
+            set -l secs (math "$elapsed % 60")
+            set -l time_str (printf "%d:%02d" $mins $secs)
+            printf "\r   %s%s%s  triage  %s%s%s" $dim $spinner_frames[$frame_idx] $reset $dim $time_str $reset
             set frame_idx (math "$frame_idx % 10 + 1")
             sleep 0.05
         end
-        echo ""
+        set -l elapsed (math (date +%s) - $round_start)
+        set -l mins (math "floor($elapsed / 60)")
+        set -l secs (math "$elapsed % 60")
+        set -l time_str (printf "%d:%02d" $mins $secs)
+        printf "\r                                                           \r"
+        echo "   "(set_color white)"●"(set_color normal)"  triage  "(set_color brblack)"$time_str"(set_color normal)
 
         # check triage result
         if grep -q NO_ISSUES_FOUND $round_dir/triage.md
@@ -218,7 +236,6 @@ Your job:
 
         # --- fix phase (runs in Evelyn's pane) ---
         echo ""
-        echo "   "(set_color white)"●"(set_color normal)"  fix"
 
         set -l fix_sentinel "$round_dir/.done_fix"
         set -l fix_prompt "You are a senior engineer. Read the triaged code-review issues at $round_dir/triage.md using the Read tool. Fix every issue listed. Do not fix anything not listed. After fixing, commit your changes with a clear message referencing what was fixed. When completely done, run: touch $fix_sentinel"
@@ -228,11 +245,20 @@ Your job:
 
         set frame_idx 1
         while not test -f $fix_sentinel
-            printf "\r   $dim$spinner_frames[$frame_idx]$reset  fixing..."
+            set -l elapsed (math (date +%s) - $round_start)
+            set -l mins (math "floor($elapsed / 60)")
+            set -l secs (math "$elapsed % 60")
+            set -l time_str (printf "%d:%02d" $mins $secs)
+            printf "\r   %s%s%s  fix  %s%s%s" $dim $spinner_frames[$frame_idx] $reset $dim $time_str $reset
             set frame_idx (math "$frame_idx % 10 + 1")
             sleep 0.05
         end
-        echo ""
+        set -l elapsed (math (date +%s) - $round_start)
+        set -l mins (math "floor($elapsed / 60)")
+        set -l secs (math "$elapsed % 60")
+        set -l time_str (printf "%d:%02d" $mins $secs)
+        printf "\r                                                           \r"
+        echo "   "(set_color white)"●"(set_color normal)"  fix  "(set_color brblack)"$time_str"(set_color normal)
 
         set round (math $round + 1)
     end

--- a/fish/.config/fish/functions/review_auto.fish
+++ b/fish/.config/fish/functions/review_auto.fish
@@ -1,9 +1,10 @@
 function review_auto
-    # Usage: review_auto [--max-rounds N] [--provider openai|anthropic] [--panes 1-4] [--dry-run]
+    # Usage: review_auto [--max-rounds N] [--provider openai|anthropic] [--panes 1-3] [--dry-run]
     # Uses --yolo so agents can run shell tools (gh cli, git, etc.) for PR inspection.
+    # Default: 3 reviewers (Evelyn, Vivian, Stella) in 4-quadrant layout.
     set -l max_rounds 3
     set -l provider anthropic
-    set -l num_panes 4
+    set -l num_panes 3
     set -l dry_run false
 
     set -l i 1
@@ -22,14 +23,14 @@ function review_auto
                 set dry_run true
             case '*'
                 echo "Unknown argument: $argv[$i]"
-                echo "Usage: review_auto [--max-rounds N] [--provider openai|anthropic] [--panes 1-4] [--dry-run]"
+                echo "Usage: review_auto [--max-rounds N] [--provider openai|anthropic] [--panes 1-3] [--dry-run]"
                 return 1
         end
         set i (math $i + 1)
     end
 
-    if test $num_panes -lt 1 -o $num_panes -gt 4
-        echo "Pane count must be between 1 and 4"
+    if test $num_panes -lt 1 -o $num_panes -gt 3
+        echo "Pane count must be between 1 and 3"
         return 1
     end
 
@@ -54,12 +55,11 @@ function review_auto
     set -l review_cmd "cursor-agent --yolo --model $review_model"
 
     # reviewer identities and prompts
-    set -l names Evelyn Vivian Stella Tiffany
+    set -l names Evelyn Vivian Stella
     set -l base_prompts \
         "You are Evelyn. Use the local review skill to review PR #$pr_number in read-only mode and follow its exact response format." \
         "You are Vivian. Use the local review skill to review PR #$pr_number in read-only mode and follow its exact response format." \
-        "You are Stella. Use the local review skill to review PR #$pr_number in read-only mode and follow its exact response format. Focus on critical bugs, security vulnerabilities, and logic errors." \
-        "You are Tiffany. Use the local review skill to review PR #$pr_number in read-only mode and follow its exact response format. Focus on dead code, unused imports, and unreachable code paths."
+        "You are Stella. Use the local review skill to review PR #$pr_number in read-only mode and follow its exact response format. Focus on dead code, unused imports, and unreachable code paths."
 
     echo "┌─────────────────────────────────────────────┐"
     echo "│  review_auto — PR #$pr_number"
@@ -67,46 +67,34 @@ function review_auto
     echo "│  session: $session_dir"
     echo "└─────────────────────────────────────────────┘"
 
-    # --- split panes: orchestrator + Evelyn on top, rest on bottom ---
+    # --- split panes: 4 quadrants (orchestrator + 3 reviewers) ---
     # Layout:
     # ┌─────────────────────┬─────────────────────┐
     # │   ORCHESTRATOR      │      Evelyn         │
-    # ├───────────┬─────────┴───────┬─────────────┤
-    # │ Vivian    │    Stella       │   Tiffany   │
-    # └───────────┴─────────────────┴─────────────┘
-    #
-    # Split order matters! Must split top/bottom FIRST (while pane is full width),
-    # then split each row horizontally.
+    # ├─────────────────────┼─────────────────────┤
+    # │     Vivian          │      Stella         │
+    # └─────────────────────┴─────────────────────┘
     set -l pane_0 $WEZTERM_PANE
     set -l pane_ids
 
-    # First: split top/bottom to create the two rows
-    set -l pane_bottom (wezterm cli split-pane --pane-id $pane_0 --bottom)
+    # Create quadrants (same pattern as wez_quadrants.example.fish)
+    set -l pane_bottom_left (wezterm cli split-pane --pane-id $pane_0 --bottom)
+    set -l pane_bottom_right (wezterm cli split-pane --pane-id $pane_bottom_left --right)
+    set -l pane_top_right (wezterm cli split-pane --pane-id $pane_0 --right)
 
-    # Now split the top row: orchestrator | Evelyn
-    set -l pane_evelyn (wezterm cli split-pane --pane-id $pane_0 --right)
-    set pane_ids $pane_evelyn
+    # pane_ids: [Evelyn (top-right), Vivian (bottom-left), Stella (bottom-right)]
+    set pane_ids $pane_top_right $pane_bottom_left $pane_bottom_right
 
-    if test $num_panes -ge 2
-        # Vivian is already in pane_bottom (bottom-left after we split it)
-        # But we need to track it - it's pane_bottom itself for now
-        set -a pane_ids $pane_bottom
-
-        if test $num_panes -ge 3
-            # Split bottom row: Vivian | Stella
-            set -l pane_stella (wezterm cli split-pane --pane-id $pane_bottom --right)
-            set -a pane_ids $pane_stella
-
-            if test $num_panes -ge 4
-                # Split again: Vivian | Stella | Tiffany
-                set -l pane_tiffany (wezterm cli split-pane --pane-id $pane_stella --right)
-                set -a pane_ids $pane_tiffany
-            end
-        end
-    else
-        # Only 1 reviewer (Evelyn) - kill the unused bottom pane
-        wezterm cli kill-pane --pane-id $pane_bottom
+    # For fewer panes, kill unused ones
+    if test $num_panes -lt 3
+        wezterm cli kill-pane --pane-id $pane_bottom_right
     end
+    if test $num_panes -lt 2
+        wezterm cli kill-pane --pane-id $pane_bottom_left
+    end
+
+    # Trim pane_ids to match num_panes
+    set pane_ids $pane_ids[1..$num_panes]
 
     # --- main loop ---
     set -l round 1

--- a/fish/.config/fish/functions/review_auto.fish
+++ b/fish/.config/fish/functions/review_auto.fish
@@ -147,13 +147,15 @@ function review_auto
             rm -f $round_dir/.done_$name
         end
 
-        # dispatch review agents to panes
+        # dispatch review agents to panes (prompts written to temp files to avoid shell metacharacter issues)
         for j in (seq $num_panes)
             set -l name (string lower $names[$j])
             set -l outfile "$round_dir/review_$name.md"
             set -l sentinel "$round_dir/.done_$name"
             set -l prompt "$base_prompts[$j] IMPORTANT: When done, write your complete review to $outfile using the Write tool. Then run this shell command: touch $sentinel"
-            set -l cmd "$review_cmd \"$prompt\""
+            set -l prompt_file "$round_dir/prompt_review_$name.txt"
+            printf '%s' "$prompt" > $prompt_file
+            set -l cmd "$review_cmd \"\$(cat $prompt_file)\""
             printf '%s\r' "$cmd" | wezterm cli send-text --no-paste --pane-id $pane_ids[$j]
             sleep 0.5 # stagger to avoid cli-config.json race condition
         end
@@ -214,7 +216,9 @@ function review_auto
         set -l triage_sentinel "$round_dir/.done_triage"
         set -l triage_prompt "You are a code-review triage agent. Read the review output files at: $file_list. Read all review files using the Read tool. Filter out nitpicks, style-only comments, and false positives. Identify ONLY real bugs, logic errors, security vulnerabilities, or missing error handling. If a review file is empty or contains an error, skip it. Write your verdict to $round_dir/triage.md. If there are NO real issues: write ONLY the text NO_ISSUES_FOUND (nothing else, just that one line). If there ARE real issues: write each issue with file path, line number, severity (critical/high/medium), and description. Do NOT include the string NO_ISSUES_FOUND anywhere. When completely done, run this shell command: touch $triage_sentinel"
 
-        set -l triage_cmd "cursor-agent --yolo --model $triage_model \"$triage_prompt\""
+        set -l triage_prompt_file "$round_dir/prompt_triage.txt"
+        printf '%s' "$triage_prompt" > $triage_prompt_file
+        set -l triage_cmd "cursor-agent --yolo --model $triage_model \"\$(cat $triage_prompt_file)\""
         printf '%s\r' "$triage_cmd" | wezterm cli send-text --no-paste --pane-id $work_pane
 
         set frame_idx 1
@@ -240,8 +244,8 @@ function review_auto
         printf "\r                                                           \r"
         echo " "(set_color green)"✔"(set_color normal)"  Triage  "(set_color brblack)"$time_str"(set_color normal)
 
-        # check triage result - must be on its own line to avoid false matches
-        if grep -qx NO_ISSUES_FOUND $round_dir/triage.md 2>/dev/null
+        # check triage result - trim whitespace and match robustly
+        if string match -qr '^\s*NO_ISSUES_FOUND\s*$' < $round_dir/triage.md 2>/dev/null
             wezterm cli kill-pane --pane-id $work_pane &>/dev/null
             echo " "(set_color green)"●"(set_color normal)"  "(set_color --bold)"clean"(set_color normal)" "(set_color brblack)"— no issues found"(set_color normal)
             echo ""
@@ -260,7 +264,9 @@ function review_auto
         set -l fix_sentinel "$round_dir/.done_fix"
         set -l fix_prompt "Read the triaged code-review issues at $round_dir/triage.md using the Read tool. Fix every issue listed. Do not fix anything not listed. After fixing, commit your changes with a clear message referencing what was fixed, then push to the remote branch with git push. Then use the /pr skill to update the PR title and description. When completely done, run this shell command: touch $fix_sentinel"
 
-        set -l fix_cmd "cursor-agent --yolo --model $fix_model \"$fix_prompt\""
+        set -l fix_prompt_file "$round_dir/prompt_fix.txt"
+        printf '%s' "$fix_prompt" > $fix_prompt_file
+        set -l fix_cmd "cursor-agent --yolo --model $fix_model \"\$(cat $fix_prompt_file)\""
         printf '%s\r' "$fix_cmd" | wezterm cli send-text --no-paste --pane-id $work_pane
 
         set frame_idx 1

--- a/fish/.config/fish/functions/review_auto.fish
+++ b/fish/.config/fish/functions/review_auto.fish
@@ -210,20 +210,9 @@ function review_auto
         set -l file_list (string join ", " $review_files)
 
         set -l triage_sentinel "$round_dir/.done_triage"
-        set -l triage_prompt_file "$round_dir/triage_prompt.txt"
-        echo "You are a senior code-review triage agent. Read the review output files at: $file_list
+        set -l triage_prompt "You are a senior code-review triage agent. Read the review output files at: $file_list. Read all review files using the Read tool. Filter out nitpicks, style-only comments, and false positives. Identify ONLY real bugs, logic errors, security vulnerabilities, or missing error handling. If a review file is empty or contains an error, skip it. Write your verdict to $round_dir/triage.md. If there are NO real issues: write ONLY the text NO_ISSUES_FOUND (nothing else, just that one line). If there ARE real issues: write each issue with file path, line number, severity (critical/high/medium), and description. Do NOT include the string NO_ISSUES_FOUND anywhere."
 
-Your job:
-- Read all review files using the Read tool
-- Filter out nitpicks, style-only comments, and false positives
-- Identify ONLY real bugs, logic errors, security vulnerabilities, or missing error handling
-- If a review file is empty or contains an error, skip it
-
-IMPORTANT - Write your verdict to $round_dir/triage.md:
-- If there are NO real issues: write ONLY the text 'NO_ISSUES_FOUND' (nothing else, just that one line)
-- If there ARE real issues: write each issue with file path, line number, severity (critical/high/medium), and description. Do NOT include the string NO_ISSUES_FOUND anywhere." >$triage_prompt_file
-
-        set -l triage_cmd "cursor-agent --yolo --model $triage_model -p \"(cat $triage_prompt_file)\" && touch $triage_sentinel"
+        set -l triage_cmd "cursor-agent --yolo --model $triage_model \"$triage_prompt\"; touch $triage_sentinel"
         printf '%s\r' "$triage_cmd" | wezterm cli send-text --no-paste --pane-id $work_pane
 
         set frame_idx 1
@@ -263,10 +252,9 @@ IMPORTANT - Write your verdict to $round_dir/triage.md:
         set work_pane (wezterm cli split-pane --pane-id $pane_0 --right)
 
         set -l fix_sentinel "$round_dir/.done_fix"
-        set -l fix_prompt_file "$round_dir/fix_prompt.txt"
-        echo "You are a senior engineer. Read the triaged code-review issues at $round_dir/triage.md using the Read tool. Fix every issue listed. Do not fix anything not listed. After fixing, commit your changes with a clear message referencing what was fixed, then push to the remote branch (git push)." >$fix_prompt_file
+        set -l fix_prompt "You are a senior engineer. Read the triaged code-review issues at $round_dir/triage.md using the Read tool. Fix every issue listed. Do not fix anything not listed. After fixing, commit your changes with a clear message referencing what was fixed, then push to the remote branch with git push."
 
-        set -l fix_cmd "cursor-agent --yolo --model $fix_model -p \"(cat $fix_prompt_file)\" && touch $fix_sentinel"
+        set -l fix_cmd "cursor-agent --yolo --model $fix_model \"$fix_prompt\"; touch $fix_sentinel"
         printf '%s\r' "$fix_cmd" | wezterm cli send-text --no-paste --pane-id $work_pane
 
         set frame_idx 1

--- a/fish/.config/fish/functions/review_auto.fish
+++ b/fish/.config/fish/functions/review_auto.fish
@@ -344,8 +344,9 @@ function review_auto
         printf "\r                                                           \r"
         echo " "(set_color green)"✔"(set_color normal)" Triaged  "(set_color brblack)"$time_str"(set_color normal)
 
-        # check triage result - trim whitespace and match robustly
-        if string match -qr '^\s*NO_ISSUES_FOUND\s*$' < $round_dir/triage.md 2>/dev/null
+        # check triage result - compare trimmed entire file to exact string
+        set -l _triage_content (string trim (cat $round_dir/triage.md 2>/dev/null))
+        if test "$_triage_content" = NO_ISSUES_FOUND
             wezterm cli kill-pane --pane-id $work_pane &>/dev/null
             echo " "(set_color green)"●"(set_color normal)"  "(set_color --bold)"clean"(set_color normal)" "(set_color brblack)"— no issues found"(set_color normal)
             echo ""

--- a/fish/.config/fish/functions/review_auto.fish
+++ b/fish/.config/fish/functions/review_auto.fish
@@ -17,6 +17,10 @@ function review_auto
                     echo "Missing value for --max-rounds"
                     return 1
                 end
+                if not string match -qr '^\d+$' -- $argv[$i]; or test $argv[$i] -le 0
+                    echo "Invalid --max-rounds value: '$argv[$i]' (must be a positive integer)"
+                    return 1
+                end
                 set max_rounds $argv[$i]
             case --provider
                 set i (math $i + 1)
@@ -95,10 +99,25 @@ function review_auto
 
     # Step 1: split horizontally to create bottom row
     set -l pane_bottom (wezterm cli split-pane --pane-id $pane_0 --bottom)
+    if test -z "$pane_bottom"
+        echo "Failed to create bottom pane (split-pane returned empty ID)"
+        return 1
+    end
     # Step 2: split top row to create Evelyn (top-right)
     set -l pane_evelyn (wezterm cli split-pane --pane-id $pane_0 --right)
+    if test -z "$pane_evelyn"
+        echo "Failed to create Evelyn pane (split-pane returned empty ID)"
+        wezterm cli kill-pane --pane-id $pane_bottom &>/dev/null
+        return 1
+    end
     # Step 3: split bottom row to create Stella (bottom-right)
     set -l pane_stella (wezterm cli split-pane --pane-id $pane_bottom --right)
+    if test -z "$pane_stella"
+        echo "Failed to create Stella pane (split-pane returned empty ID)"
+        wezterm cli kill-pane --pane-id $pane_evelyn &>/dev/null
+        wezterm cli kill-pane --pane-id $pane_bottom &>/dev/null
+        return 1
+    end
     # pane_bottom is now Vivian (bottom-left)
     set -l pane_vivian $pane_bottom
 
@@ -132,8 +151,23 @@ function review_auto
         # On round 2+, recreate reviewer panes (same quadrant layout as initial)
         if test $round -gt 1
             set -l pb (wezterm cli split-pane --pane-id $pane_0 --bottom)
+            if test -z "$pb"
+                echo "Failed to recreate bottom pane in round $round"
+                return 1
+            end
             set -l pe (wezterm cli split-pane --pane-id $pane_0 --right)
+            if test -z "$pe"
+                echo "Failed to recreate Evelyn pane in round $round"
+                wezterm cli kill-pane --pane-id $pb &>/dev/null
+                return 1
+            end
             set -l ps (wezterm cli split-pane --pane-id $pb --right)
+            if test -z "$ps"
+                echo "Failed to recreate Stella pane in round $round"
+                wezterm cli kill-pane --pane-id $pe &>/dev/null
+                wezterm cli kill-pane --pane-id $pb &>/dev/null
+                return 1
+            end
             set pane_ids $pe $pb $ps
             if test $num_panes -lt 3
                 wezterm cli kill-pane --pane-id $ps &>/dev/null

--- a/fish/.config/fish/functions/review_auto.fish
+++ b/fish/.config/fish/functions/review_auto.fish
@@ -410,7 +410,8 @@ function review_auto
             sleep 0.15
         end
         printf "\r                                                           \r"
-        echo " "(set_color green)"✔"(set_color normal)" Fixed"
+        set -l _commit_msg (git log -1 --format='%s' 2>/dev/null)
+        echo " "(set_color green)"✔"(set_color normal)" Fixed "(set_color brblack)"$_commit_msg"(set_color normal)
 
         # kill work pane before next iteration
         wezterm cli kill-pane --pane-id $work_pane &>/dev/null

--- a/fish/.config/fish/functions/review_auto.fish
+++ b/fish/.config/fish/functions/review_auto.fish
@@ -67,10 +67,9 @@ function review_auto
         return 1
     end
 
-    set -l pr_json (gh pr view --json number,url,title 2>/dev/null)
-    set -l pr_number (echo $pr_json | string match -r '"number":(\d+)' | tail -1)
-    set -l pr_url (echo $pr_json | string match -r '"url":"([^"]+)"' | tail -1)
-    set -l pr_title (echo $pr_json | string match -r '"title":"([^"]+)"' | tail -1)
+    set -l pr_number (gh pr view --json number --jq '.number' 2>/dev/null)
+    set -l pr_url (gh pr view --json url --jq '.url' 2>/dev/null)
+    set -l pr_title (gh pr view --json title --jq '.title' 2>/dev/null)
     if test -z "$pr_number"
         echo "No PR found for current branch"
         return 1
@@ -186,12 +185,14 @@ function review_auto
             set -l pb (wezterm cli split-pane --pane-id $pane_0 --bottom)
             if test -z "$pb"
                 echo "Failed to recreate bottom pane in round $round"
+                rm -rf $session_dir
                 return 1
             end
             set -l pe (wezterm cli split-pane --pane-id $pane_0 --right)
             if test -z "$pe"
                 echo "Failed to recreate Evelyn pane in round $round"
                 wezterm cli kill-pane --pane-id $pb &>/dev/null
+                rm -rf $session_dir
                 return 1
             end
             set -l ps (wezterm cli split-pane --pane-id $pb --right)
@@ -199,6 +200,7 @@ function review_auto
                 echo "Failed to recreate Stella pane in round $round"
                 wezterm cli kill-pane --pane-id $pe &>/dev/null
                 wezterm cli kill-pane --pane-id $pb &>/dev/null
+                rm -rf $session_dir
                 return 1
             end
             set pane_ids $pe $pb $ps
@@ -266,6 +268,7 @@ function review_auto
                 for pane in $pane_ids
                     wezterm cli kill-pane --pane-id $pane &>/dev/null
                 end
+                rm -rf $session_dir
                 return 1
             end
 
@@ -280,6 +283,7 @@ function review_auto
         set -l work_pane (wezterm cli split-pane --pane-id $pane_0 --right)
         if test -z "$work_pane"
             echo "Failed to create work pane after review phase in round $round"
+            rm -rf $session_dir
             return 1
         end
 
@@ -317,6 +321,7 @@ function review_auto
                 printf "\r                                                           \r"
                 echo " "(set_color red)"✗"(set_color normal)"  Triage phase timed out after $phase_timeout seconds in round $round"
                 wezterm cli kill-pane --pane-id $work_pane &>/dev/null
+                rm -rf $session_dir
                 return 1
             end
 
@@ -329,15 +334,16 @@ function review_auto
         set work_pane (wezterm cli split-pane --pane-id $pane_0 --right)
         if test -z "$work_pane"
             echo "Failed to create work pane after triage phase in round $round"
+            rm -rf $session_dir
             return 1
         end
 
         printf "\r                                                           \r"
         echo " "(set_color green)"✔"(set_color normal)" Triaged"
 
-        # check triage result - compare trimmed entire file to exact string
+        # check triage result - tolerate minor LLM formatting variance around the token
         set -l _triage_content (cat $round_dir/triage.md 2>/dev/null | string trim)
-        if test "$_triage_content" = NO_ISSUES_FOUND
+        if string match -qr '^\s*NO_ISSUES_FOUND\s*$' -- "$_triage_content"
             wezterm cli kill-pane --pane-id $work_pane &>/dev/null
             echo " "(set_color green)"✔"(set_color normal)" No issues found"
             set -l total_dur (math (date +%s) - $session_start)
@@ -386,6 +392,7 @@ function review_auto
                 printf "\r                                                           \r"
                 echo " "(set_color red)"✗"(set_color normal)"  Fix phase timed out after $phase_timeout seconds in round $round"
                 wezterm cli kill-pane --pane-id $work_pane &>/dev/null
+                rm -rf $session_dir
                 return 1
             end
 
@@ -409,5 +416,6 @@ function review_auto
     echo ""
     echo " "(set_color brblack)$pr_url" · "(printf "%dm %ds" $total_dur_m $total_dur_s)(set_color normal)
     echo ""
+    rm -rf $session_dir
     return 1
 end

--- a/fish/.config/fish/functions/review_auto.fish
+++ b/fish/.config/fish/functions/review_auto.fish
@@ -231,8 +231,8 @@ function review_auto
         end
 
         # poll for all reviewers to finish
-        set -l dot_frames "." ".." "..." "..."
-        set -l dot_colors green green green white
+        set -l dot_frames "." ".." "..."
+        set -l dot_colors green white green
         set -l frame_idx 1
         while true
             set -l done_count 0
@@ -268,8 +268,8 @@ function review_auto
                 return 1
             end
 
-            set frame_idx (math "$frame_idx % 4 + 1")
-            sleep 0.3
+            set frame_idx (math "$frame_idx % 3 + 1")
+            sleep 0.15
         end
         set -l elapsed (math (date +%s) - $round_start)
         set -l mins (math "floor($elapsed / 60)")
@@ -324,8 +324,8 @@ function review_auto
                 return 1
             end
 
-            set frame_idx (math "$frame_idx % 4 + 1")
-            sleep 0.3
+            set frame_idx (math "$frame_idx % 3 + 1")
+            sleep 0.15
         end
         set -l elapsed (math (date +%s) - $round_start)
         set -l mins (math "floor($elapsed / 60)")
@@ -391,8 +391,8 @@ function review_auto
                 return 1
             end
 
-            set frame_idx (math "$frame_idx % 4 + 1")
-            sleep 0.3
+            set frame_idx (math "$frame_idx % 3 + 1")
+            sleep 0.15
         end
         set -l elapsed (math (date +%s) - $round_start)
         set -l mins (math "floor($elapsed / 60)")

--- a/fish/.config/fish/functions/review_auto.fish
+++ b/fish/.config/fish/functions/review_auto.fish
@@ -253,7 +253,7 @@ function review_auto
             set -l secs (math "$elapsed % 60")
             set -l time_str (printf "%d:%02d" $mins $secs)
             set -l dots (printf "%-4s" $dot_frames[$frame_idx])
-            printf "\r %s•%s Reviewing%s%s(%s/%s)%s  %s %s%s%s" (set_color $dot_colors[$frame_idx]) $reset "$dots" $dim $round $max_rounds $reset "$status_line" $dim $time_str $reset
+            printf "\r %s•%s  Reviewing%s%s(%s/%s)%s  %s %s%s%s" (set_color $dot_colors[$frame_idx]) $reset "$dots" $dim $round $max_rounds $reset "$status_line" $dim $time_str $reset
 
             if test $done_count -ge $num_panes
                 break
@@ -314,7 +314,7 @@ function review_auto
             set -l secs (math "$elapsed % 60")
             set -l time_str (printf "%d:%02d" $mins $secs)
             set -l dots (printf "%-4s" $dot_frames[$frame_idx])
-            printf "\r %s•%s Triaging%s %s%s%s" (set_color $dot_colors[$frame_idx]) $reset "$dots" $dim $time_str $reset
+            printf "\r %s•%s  Triaging%s %s%s%s" (set_color $dot_colors[$frame_idx]) $reset "$dots" $dim $time_str $reset
 
             set -l phase_elapsed (math (date +%s) - $triage_start)
             if test $phase_elapsed -ge $phase_timeout
@@ -381,7 +381,7 @@ function review_auto
             set -l secs (math "$elapsed % 60")
             set -l time_str (printf "%d:%02d" $mins $secs)
             set -l dots (printf "%-4s" $dot_frames[$frame_idx])
-            printf "\r %s•%s Fixing%s %s%s%s" (set_color $dot_colors[$frame_idx]) $reset "$dots" $dim $time_str $reset
+            printf "\r %s•%s  Fixing%s %s%s%s" (set_color $dot_colors[$frame_idx]) $reset "$dots" $dim $time_str $reset
 
             set -l phase_elapsed (math (date +%s) - $fix_start)
             if test $phase_elapsed -ge $phase_timeout

--- a/fish/.config/fish/functions/review_auto.fish
+++ b/fish/.config/fish/functions/review_auto.fish
@@ -116,9 +116,9 @@ function review_auto
         mkdir -p $round_dir
 
         echo ""
-        echo "   $bold round $round$reset$dim / $max_rounds$reset"
+        echo "   "(set_color --bold)"round $round"(set_color normal)(set_color brblack)" / $max_rounds"(set_color normal)
         echo ""
-        echo "   $white●$reset  review"
+        echo "   "(set_color white)"●"(set_color normal)"  review"
 
         # clean sentinel files and kill any lingering agents from previous round
         for j in (seq $num_panes)
@@ -157,7 +157,7 @@ function review_auto
                 end
             end
             
-            printf "\r   $dim$spinner_frames[$frame_idx]$reset  $status_line"
+            printf "\r   %s%s%s  %s" $dim $spinner_frames[$frame_idx] $reset "$status_line"
             
             if test $done_count -ge $num_panes
                 break
@@ -168,7 +168,7 @@ function review_auto
         end
         echo ""
         echo ""
-        echo "   $white●$reset  triage"
+        echo "   "(set_color white)"●"(set_color normal)"  triage"
 
         set -l review_files
         for j in (seq $num_panes)
@@ -204,21 +204,21 @@ Your job:
         # check triage result
         if grep -q "NO_ISSUES_FOUND" $round_dir/triage.md
             echo ""
-            echo "   $green●$reset  $bold clean$reset $dim— no issues found$reset"
+            echo "   "(set_color green)"●"(set_color normal)"  "(set_color --bold)"clean"(set_color normal)" "(set_color brblack)"— no issues found"(set_color normal)
             echo ""
             return 0
         end
 
         if test "$dry_run" = true
             echo ""
-            echo "   $yellow●$reset  $bold dry run$reset $dim— issues found, skipping fix$reset"
+            echo "   "(set_color yellow)"●"(set_color normal)"  "(set_color --bold)"dry run"(set_color normal)" "(set_color brblack)"— issues found, skipping fix"(set_color normal)
             echo ""
             return 0
         end
 
         # --- fix phase (runs in Evelyn's pane) ---
         echo ""
-        echo "   $white●$reset  fix"
+        echo "   "(set_color white)"●"(set_color normal)"  fix"
 
         set -l fix_sentinel "$round_dir/.done_fix"
         set -l fix_prompt "You are a senior engineer. Read the triaged code-review issues at $round_dir/triage.md using the Read tool. Fix every issue listed. Do not fix anything not listed. After fixing, commit your changes with a clear message referencing what was fixed. When completely done, run: touch $fix_sentinel"
@@ -238,7 +238,7 @@ Your job:
     end
 
     echo ""
-    echo "   $red●$reset  $bold max rounds$reset $dim— review manually$reset"
+    echo "   "(set_color red)"●"(set_color normal)"  "(set_color --bold)"max rounds"(set_color normal)" "(set_color brblack)"— review manually"(set_color normal)
     echo ""
     return 1
 end

--- a/fish/.config/fish/functions/review_auto.fish
+++ b/fish/.config/fish/functions/review_auto.fish
@@ -76,6 +76,7 @@ function review_auto
     echo ""
     echo "  $bold review_auto$reset  $dim·$reset  PR #$cyan$pr_number$reset"
     echo "  $dim$provider · $num_panes reviewers · $max_rounds rounds max$reset"
+    echo ""
 
     # --- split panes: 4 quadrants (orchestrator + 3 reviewers) ---
     # Layout:
@@ -114,6 +115,7 @@ function review_auto
 
         echo ""
         echo "  $bold round $round$reset$dim / $max_rounds$reset"
+        echo ""
         echo "  $white●$reset  review"
 
         # clean sentinel files and kill any lingering agents from previous round
@@ -163,8 +165,7 @@ function review_auto
             sleep 0.05
         end
         echo ""
-
-        # --- triage phase (runs in Evelyn's pane) ---
+        echo ""
         echo "  $white●$reset  triage"
 
         set -l review_files
@@ -200,18 +201,21 @@ Your job:
 
         # check triage result
         if grep -q "NO_ISSUES_FOUND" $round_dir/triage.md
+            echo ""
             echo "  $green●$reset  $bold clean$reset $dim— no issues found$reset"
             echo ""
             return 0
         end
 
         if test "$dry_run" = true
+            echo ""
             echo "  $yellow●$reset  $bold dry run$reset $dim— issues found, skipping fix$reset"
             echo ""
             return 0
         end
 
         # --- fix phase (runs in Evelyn's pane) ---
+        echo ""
         echo "  $white●$reset  fix"
 
         set -l fix_sentinel "$round_dir/.done_fix"
@@ -231,6 +235,7 @@ Your job:
         set round (math $round + 1)
     end
 
+    echo ""
     echo "  $red●$reset  $bold max rounds$reset $dim— review manually$reset"
     echo ""
     return 1

--- a/fish/.config/fish/functions/review_auto.fish
+++ b/fish/.config/fish/functions/review_auto.fish
@@ -74,15 +74,8 @@ function review_auto
     set -l white (set_color white)
     
     echo ""
-    echo "$dim───────────────────────────────────────────────────$reset"
-    echo ""
     echo "  $bold review_auto$reset  $dim·$reset  PR #$cyan$pr_number$reset"
-    echo ""
-    echo "  $dim provider$reset   $provider"
-    echo "  $dim reviewers$reset  $num_panes"
-    echo "  $dim rounds$reset     $max_rounds max"
-    echo ""
-    echo "$dim───────────────────────────────────────────────────$reset"
+    echo "  $dim$provider · $num_panes reviewers · $max_rounds rounds max$reset"
 
     # --- split panes: 4 quadrants (orchestrator + 3 reviewers) ---
     # Layout:
@@ -120,11 +113,8 @@ function review_auto
         mkdir -p $round_dir
 
         echo ""
-        echo ""
         echo "  $bold round $round$reset$dim / $max_rounds$reset"
-        echo ""
         echo "  $white●$reset  review"
-        echo ""
 
         # clean sentinel files and kill any lingering agents from previous round
         for j in (seq $num_panes)
@@ -173,11 +163,9 @@ function review_auto
             sleep 0.05
         end
         echo ""
-        echo ""
 
         # --- triage phase (runs in Evelyn's pane) ---
         echo "  $white●$reset  triage"
-        echo ""
 
         set -l review_files
         for j in (seq $num_panes)
@@ -209,18 +197,15 @@ Your job:
             sleep 0.05
         end
         echo ""
-        echo ""
 
         # check triage result
         if grep -q "NO_ISSUES_FOUND" $round_dir/triage.md
-            echo ""
             echo "  $green●$reset  $bold clean$reset $dim— no issues found$reset"
             echo ""
             return 0
         end
 
         if test "$dry_run" = true
-            echo ""
             echo "  $yellow●$reset  $bold dry run$reset $dim— issues found, skipping fix$reset"
             echo ""
             return 0
@@ -228,7 +213,6 @@ Your job:
 
         # --- fix phase (runs in Evelyn's pane) ---
         echo "  $white●$reset  fix"
-        echo ""
 
         set -l fix_sentinel "$round_dir/.done_fix"
         set -l fix_prompt "You are a senior engineer. Read the triaged code-review issues at $round_dir/triage.md using the Read tool. Fix every issue listed. Do not fix anything not listed. After fixing, commit your changes with a clear message referencing what was fixed. When completely done, run: touch $fix_sentinel"
@@ -243,12 +227,10 @@ Your job:
             sleep 0.05
         end
         echo ""
-        echo ""
 
         set round (math $round + 1)
     end
 
-    echo ""
     echo "  $red●$reset  $bold max rounds$reset $dim— review manually$reset"
     echo ""
     return 1

--- a/fish/.config/fish/functions/review_auto.fish
+++ b/fish/.config/fish/functions/review_auto.fish
@@ -55,7 +55,7 @@ function review_auto
 
     # reviewer identities and prompts
     set -l names Evelyn Vivian Stella Tiffany
-    set -l prompts \
+    set -l base_prompts \
         "You are Evelyn. Use the local review skill to review PR #$pr_number in read-only mode and follow its exact response format." \
         "You are Vivian. Use the local review skill to review PR #$pr_number in read-only mode and follow its exact response format." \
         "You are Stella. Use the local review skill to review PR #$pr_number in read-only mode and follow its exact response format. Focus on critical bugs, security vulnerabilities, and logic errors." \
@@ -119,7 +119,9 @@ function review_auto
         # dispatch review agents to panes
         for j in (seq $num_panes)
             set -l name (string lower $names[$j])
-            set -l cmd "$review_cmd \"$prompts[$j]\" 2>&1 | tee $round_dir/review_$name.md; touch $round_dir/.done_$name"
+            set -l outfile "$round_dir/review_$name.md"
+            set -l prompt "$base_prompts[$j] IMPORTANT: When done, write your complete review to $outfile using the Write tool."
+            set -l cmd "$review_cmd \"$prompt\"; touch $round_dir/.done_$name"
             printf '%s\r' "$cmd" | wezterm cli send-text --no-paste --pane-id $pane_ids[$j]
         end
 

--- a/fish/.config/fish/functions/review_auto.fish
+++ b/fish/.config/fish/functions/review_auto.fish
@@ -157,7 +157,12 @@ function review_auto
     printf "\n\n"
     set -l pr_label "PR #$pr_number"
     if test -n "$pr_title"
-        set pr_label $pr_title
+        set -l max_len 40
+        if test (string length "$pr_title") -gt $max_len
+            set pr_label (string sub -l $max_len "$pr_title")"…"
+        else
+            set pr_label $pr_title
+        end
     end
     echo " "(set_color --bold)"review_auto"(set_color normal)" "(set_color brblack)"·"(set_color normal)" "\e]8\;\;$pr_url\e\\(set_color cyan)$pr_label(set_color normal)\e]8\;\;\e\\
     echo " "(set_color brblack)"$provider · $num_panes reviewers"(set_color normal)

--- a/fish/.config/fish/functions/review_auto.fish
+++ b/fish/.config/fish/functions/review_auto.fish
@@ -253,7 +253,7 @@ function review_auto
             set -l secs (math "$elapsed % 60")
             set -l time_str (printf "%d:%02d" $mins $secs)
             set -l dots (printf "%-4s" $dot_frames[$frame_idx])
-            printf "\r %s•%s  Reviewing%s%s(%s/%s)%s  %s %s%s%s" (set_color $dot_colors[$frame_idx]) $reset "$dots" $dim $round $max_rounds $reset "$status_line" $dim $time_str $reset
+            printf "\r  %s•%s Reviewing%s%s(%s/%s)%s  %s %s%s%s" (set_color $dot_colors[$frame_idx]) $reset "$dots" $dim $round $max_rounds $reset "$status_line" $dim $time_str $reset
 
             if test $done_count -ge $num_panes
                 break
@@ -288,7 +288,7 @@ function review_auto
         end
 
         printf "\r                                                           \r"
-        echo " "(set_color green)"✔"(set_color normal)"  Reviewed "(set_color brblack)"($round/$max_rounds)"(set_color normal)"  $status_line"(set_color brblack)"$time_str"(set_color normal)
+        echo "  "(set_color green)"✔"(set_color normal)" Reviewed "(set_color brblack)"($round/$max_rounds)"(set_color normal)"  $status_line"(set_color brblack)"$time_str"(set_color normal)
 
         # --- triage phase ---
         set -l review_files
@@ -314,7 +314,7 @@ function review_auto
             set -l secs (math "$elapsed % 60")
             set -l time_str (printf "%d:%02d" $mins $secs)
             set -l dots (printf "%-4s" $dot_frames[$frame_idx])
-            printf "\r %s•%s  Triaging%s %s%s%s" (set_color $dot_colors[$frame_idx]) $reset "$dots" $dim $time_str $reset
+            printf "\r  %s•%s Triaging%s %s%s%s" (set_color $dot_colors[$frame_idx]) $reset "$dots" $dim $time_str $reset
 
             set -l phase_elapsed (math (date +%s) - $triage_start)
             if test $phase_elapsed -ge $phase_timeout
@@ -342,7 +342,7 @@ function review_auto
         end
 
         printf "\r                                                           \r"
-        echo " "(set_color green)"✔"(set_color normal)"  Triaged  "(set_color brblack)"$time_str"(set_color normal)
+        echo "  "(set_color green)"✔"(set_color normal)" Triaged  "(set_color brblack)"$time_str"(set_color normal)
 
         # check triage result - trim whitespace and match robustly
         if string match -qr '^\s*NO_ISSUES_FOUND\s*$' < $round_dir/triage.md 2>/dev/null
@@ -381,7 +381,7 @@ function review_auto
             set -l secs (math "$elapsed % 60")
             set -l time_str (printf "%d:%02d" $mins $secs)
             set -l dots (printf "%-4s" $dot_frames[$frame_idx])
-            printf "\r %s•%s  Fixing%s %s%s%s" (set_color $dot_colors[$frame_idx]) $reset "$dots" $dim $time_str $reset
+            printf "\r  %s•%s Fixing%s %s%s%s" (set_color $dot_colors[$frame_idx]) $reset "$dots" $dim $time_str $reset
 
             set -l phase_elapsed (math (date +%s) - $fix_start)
             if test $phase_elapsed -ge $phase_timeout
@@ -399,7 +399,7 @@ function review_auto
         set -l secs (math "$elapsed % 60")
         set -l time_str (printf "%d:%02d" $mins $secs)
         printf "\r                                                           \r"
-        echo " "(set_color green)"✔"(set_color normal)"  Fixed  "(set_color brblack)"$time_str"(set_color normal)
+        echo "  "(set_color green)"✔"(set_color normal)" Fixed  "(set_color brblack)"$time_str"(set_color normal)
 
         # kill work pane before next round
         wezterm cli kill-pane --pane-id $work_pane &>/dev/null

--- a/fish/.config/fish/functions/review_auto.fish
+++ b/fish/.config/fish/functions/review_auto.fish
@@ -161,9 +161,10 @@ Your job:
 - Output ONLY the issues that are real bugs, logic errors, security vulnerabilities, or missing error handling
 - If a review file is empty or contains an error, skip it
 - If there are no real issues, output exactly the string: NO_ISSUES_FOUND
-- Format each real issue as: file path, line number, severity (critical/high/medium), and description"
+- Format each real issue as: file path, line number, severity (critical/high/medium), and description
+- IMPORTANT: Write your final verdict to $round_dir/triage.md using the Write tool. Include NO_ISSUES_FOUND in that file if there are none."
 
-        cursor-agent --yolo --print --trust --model $triage_model -p "$triage_prompt" 2>&1 | tee $round_dir/triage.md
+        cursor-agent --yolo --print --trust --model $triage_model -p "$triage_prompt"
 
         # check triage result
         if grep -q "NO_ISSUES_FOUND" $round_dir/triage.md
@@ -194,7 +195,7 @@ Your job:
 
         set -l fix_prompt "You are a senior engineer. Read the triaged code-review issues at $round_dir/triage.md using the Read tool. Fix every issue listed. Do not fix anything not listed. After fixing, commit your changes with a clear message referencing what was fixed."
 
-        cursor-agent --yolo --print --trust --model $fix_model -p "$fix_prompt" 2>&1 | tee $round_dir/fix.md
+        cursor-agent --yolo --print --trust --model $fix_model -p "$fix_prompt"
 
         set round (math $round + 1)
     end

--- a/fish/.config/fish/functions/review_auto.fish
+++ b/fish/.config/fish/functions/review_auto.fish
@@ -123,7 +123,7 @@ function review_auto
 
         printf "\n\n"
         echo " "(set_color --bold)"review_auto"(set_color normal)"  "(set_color brblack)"·"(set_color normal)"  PR #"(set_color cyan)$pr_number(set_color normal)
-        echo " "(set_color brblack)"$provider · $num_panes reviewers · round $round/$max_rounds"(set_color normal)
+        echo " "(set_color brblack)"$provider · $num_panes reviewers"(set_color normal)
         echo ""
         set -l round_start (date +%s)
 
@@ -178,7 +178,7 @@ function review_auto
             set -l mins (math "floor($elapsed / 60)")
             set -l secs (math "$elapsed % 60")
             set -l time_str (printf "%d:%02d" $mins $secs)
-            printf "\r %s%s%s  review  %s %s%s%s" $dim $spinner_frames[$frame_idx] $reset "$status_line" $dim $time_str $reset
+            printf "\r %s%s%s  Review (%s/%s)  %s %s%s%s" $dim $spinner_frames[$frame_idx] $reset $round $max_rounds "$status_line" $dim $time_str $reset
 
             if test $done_count -ge $num_panes
                 break
@@ -200,7 +200,7 @@ function review_auto
         set -l work_pane (wezterm cli split-pane --pane-id $pane_0 --right)
 
         printf "\r                                                           \r"
-        echo " "(set_color white)"●"(set_color normal)"  review  $status_line"(set_color brblack)"$time_str"(set_color normal)
+        echo " "(set_color green)"✔"(set_color normal)"  Review ($round/$max_rounds)  $status_line"(set_color brblack)"$time_str"(set_color normal)
 
         # --- triage phase ---
         set -l review_files
@@ -222,7 +222,7 @@ function review_auto
             set -l mins (math "floor($elapsed / 60)")
             set -l secs (math "$elapsed % 60")
             set -l time_str (printf "%d:%02d" $mins $secs)
-            printf "\r %s%s%s  triage  %s%s%s" $dim $spinner_frames[$frame_idx] $reset $dim $time_str $reset
+            printf "\r %s%s%s  Triage  %s%s%s" $dim $spinner_frames[$frame_idx] $reset $dim $time_str $reset
             set frame_idx (math "$frame_idx % 10 + 1")
             sleep 0.05 # ~20 FPS for smooth spinner animation
         end
@@ -231,7 +231,7 @@ function review_auto
         set -l secs (math "$elapsed % 60")
         set -l time_str (printf "%d:%02d" $mins $secs)
         printf "\r                                                           \r"
-        echo " "(set_color white)"●"(set_color normal)"  triage  "(set_color brblack)"$time_str"(set_color normal)
+        echo " "(set_color green)"✔"(set_color normal)"  Triage  "(set_color brblack)"$time_str"(set_color normal)
 
         # check triage result - must be on its own line to avoid false matches
         if grep -qx NO_ISSUES_FOUND $round_dir/triage.md 2>/dev/null
@@ -263,7 +263,7 @@ function review_auto
             set -l mins (math "floor($elapsed / 60)")
             set -l secs (math "$elapsed % 60")
             set -l time_str (printf "%d:%02d" $mins $secs)
-            printf "\r %s%s%s  fix  %s%s%s" $dim $spinner_frames[$frame_idx] $reset $dim $time_str $reset
+            printf "\r %s%s%s  Fix  %s%s%s" $dim $spinner_frames[$frame_idx] $reset $dim $time_str $reset
             set frame_idx (math "$frame_idx % 10 + 1")
             sleep 0.05 # ~20 FPS for smooth spinner animation
         end
@@ -272,7 +272,7 @@ function review_auto
         set -l secs (math "$elapsed % 60")
         set -l time_str (printf "%d:%02d" $mins $secs)
         printf "\r                                                           \r"
-        echo " "(set_color white)"●"(set_color normal)"  fix  "(set_color brblack)"$time_str"(set_color normal)
+        echo " "(set_color green)"✔"(set_color normal)"  Fix  "(set_color brblack)"$time_str"(set_color normal)
 
         # kill work pane before next round
         wezterm cli kill-pane --pane-id $work_pane &>/dev/null

--- a/fish/.config/fish/functions/review_auto.fish
+++ b/fish/.config/fish/functions/review_auto.fish
@@ -168,7 +168,7 @@ function review_auto
             set pr_label $pr_title
         end
     end
-    echo " "(set_color --bold)"review_auto"(set_color normal)" "(set_color brblack)"·"(set_color normal)" "\e]8\;\;$pr_url\e\\(set_color cyan)$pr_label(set_color normal)\e]8\;\;\e\\
+    echo " "(set_color --bold)"review_auto"(set_color normal)" "(set_color brblack)"·"(set_color normal)" "\e]8\;\;$pr_url\e\\(set_color white)$pr_label(set_color normal)\e]8\;\;\e\\
     echo " "(set_color brblack)"$provider · $num_panes reviewers"(set_color normal)
     echo ""
 

--- a/fish/.config/fish/functions/review_auto.fish
+++ b/fish/.config/fish/functions/review_auto.fish
@@ -326,15 +326,8 @@ function review_auto
             set frame_idx (math "$frame_idx % 3 + 1")
             sleep 0.15
         end
-        # kill triage pane and create fresh one before printing
-        # (pane resize happens here, before any output)
+        # kill triage pane before printing (pane resize happens here, before any output)
         wezterm cli kill-pane --pane-id $work_pane &>/dev/null
-        set work_pane (wezterm cli split-pane --pane-id $pane_0 --right)
-        if test -z "$work_pane"
-            echo "Failed to create work pane after triage phase in iteration $iter"
-            rm -rf $session_dir
-            return 1
-        end
 
         printf "\r                                                           \r"
         echo " "(set_color green)"✔"(set_color normal)" Triaged"
@@ -343,7 +336,6 @@ function review_auto
         # are compared atomically instead of per-line via fish list semantics
         set -l _triage_content (cat $iter_dir/triage.md 2>/dev/null | string collect | string trim)
         if test "$_triage_content" = "NO_ISSUES_FOUND"
-            wezterm cli kill-pane --pane-id $work_pane &>/dev/null
             echo " "(set_color green)"✔"(set_color normal)" No issues found"
             set -l total_dur (math (date +%s) - $session_start)
             set -l total_dur_m (math "floor($total_dur / 60)")
@@ -355,7 +347,6 @@ function review_auto
         end
 
         if test "$dry_run" = true
-            wezterm cli kill-pane --pane-id $work_pane &>/dev/null
             echo " "(set_color yellow)"⚠"(set_color normal)" Issues found "(set_color brblack)"(dry run)"(set_color normal)
             set -l total_dur (math (date +%s) - $session_start)
             set -l total_dur_m (math "floor($total_dur / 60)")
@@ -366,7 +357,13 @@ function review_auto
             return 0
         end
 
-        # --- fix phase (work pane already created above) ---
+        # --- fix phase ---
+        set work_pane (wezterm cli split-pane --pane-id $pane_0 --right)
+        if test -z "$work_pane"
+            echo "Failed to create work pane for fix phase in iteration $iter"
+            rm -rf $session_dir
+            return 1
+        end
 
         set -l fix_sentinel "$iter_dir/.done_fix"
         set -l fix_prompt "Read the triaged code-review issues at $iter_dir/triage.md using the Read tool. Fix every issue listed. Do not fix anything not listed. After fixing, commit your changes with a clear message referencing what was fixed, then push to the remote branch with git push. Then use the /pr skill to update the PR title and description. When completely done, run this shell command: touch $fix_sentinel"

--- a/fish/.config/fish/functions/review_auto.fish
+++ b/fish/.config/fish/functions/review_auto.fish
@@ -121,7 +121,7 @@ function review_auto
         set -l round_dir $session_dir/round_$round
         mkdir -p $round_dir
 
-        printf "\n"
+        printf "\n\n"
         echo "   "(set_color --bold)"review_auto"(set_color normal)"  "(set_color brblack)"·"(set_color normal)"  PR #"(set_color cyan)$pr_number(set_color normal)
         echo "   "(set_color brblack)"$provider · $num_panes reviewers · round $round/$max_rounds"(set_color normal)
         echo ""
@@ -173,17 +173,17 @@ function review_auto
                     set status_line "$status_line$dim$name$reset  "
                 end
             end
-            
+
             set -l elapsed (math (date +%s) - $round_start)
             set -l mins (math "floor($elapsed / 60)")
             set -l secs (math "$elapsed % 60")
             set -l time_str (printf "%d:%02d" $mins $secs)
             printf "\r   %s%s%s  review  %s %s%s%s" $dim $spinner_frames[$frame_idx] $reset "$status_line" $dim $time_str $reset
-            
+
             if test $done_count -ge $num_panes
                 break
             end
-            
+
             set frame_idx (math "$frame_idx % 10 + 1")
             sleep 0.05
         end
@@ -221,7 +221,7 @@ Your job:
 
 IMPORTANT - Write your verdict to $round_dir/triage.md:
 - If there are NO real issues: write ONLY the text 'NO_ISSUES_FOUND' (nothing else, just that one line)
-- If there ARE real issues: write each issue with file path, line number, severity (critical/high/medium), and description. Do NOT include the string NO_ISSUES_FOUND anywhere." > $triage_prompt_file
+- If there ARE real issues: write each issue with file path, line number, severity (critical/high/medium), and description. Do NOT include the string NO_ISSUES_FOUND anywhere." >$triage_prompt_file
 
         set -l triage_cmd "cursor-agent --yolo --model $triage_model -p \"(cat $triage_prompt_file)\" && touch $triage_sentinel"
         printf '%s\r' "$triage_cmd" | wezterm cli send-text --no-paste --pane-id $work_pane
@@ -264,7 +264,7 @@ IMPORTANT - Write your verdict to $round_dir/triage.md:
 
         set -l fix_sentinel "$round_dir/.done_fix"
         set -l fix_prompt_file "$round_dir/fix_prompt.txt"
-        echo "You are a senior engineer. Read the triaged code-review issues at $round_dir/triage.md using the Read tool. Fix every issue listed. Do not fix anything not listed. After fixing, commit your changes with a clear message referencing what was fixed, then push to the remote branch (git push)." > $fix_prompt_file
+        echo "You are a senior engineer. Read the triaged code-review issues at $round_dir/triage.md using the Read tool. Fix every issue listed. Do not fix anything not listed. After fixing, commit your changes with a clear message referencing what was fixed, then push to the remote branch (git push)." >$fix_prompt_file
 
         set -l fix_cmd "cursor-agent --yolo --model $fix_model -p \"(cat $fix_prompt_file)\" && touch $fix_sentinel"
         printf '%s\r' "$fix_cmd" | wezterm cli send-text --no-paste --pane-id $work_pane
@@ -285,7 +285,7 @@ IMPORTANT - Write your verdict to $round_dir/triage.md:
         set -l time_str (printf "%d:%02d" $mins $secs)
         printf "\r                                                           \r"
         echo "   "(set_color white)"●"(set_color normal)"  fix  "(set_color brblack)"$time_str"(set_color normal)
-        
+
         # kill work pane before next round
         wezterm cli kill-pane --pane-id $work_pane 2>/dev/null
 

--- a/fish/.config/fish/functions/review_auto.fish
+++ b/fish/.config/fish/functions/review_auto.fish
@@ -259,7 +259,7 @@ function review_auto
                 break
             end
 
-            if test $elapsed -ge $phase_timeout
+            if test $phase_el -ge $phase_timeout
                 printf "\r                                                           \r"
                 echo " "(set_color red)"✗"(set_color normal)"  Review phase timed out after $phase_timeout seconds in round $round"
                 for pane in $pane_ids

--- a/fish/.config/fish/functions/review_auto.fish
+++ b/fish/.config/fish/functions/review_auto.fish
@@ -232,6 +232,7 @@ function review_auto
         end
 
         # poll for all reviewers to finish
+        set -l review_start (date +%s)
         set -l dot_frames "." ".." "..."
         set -l dot_colors green white green
         set -l frame_idx 1
@@ -260,7 +261,8 @@ function review_auto
                 break
             end
 
-            if test $total_el -ge $phase_timeout
+            set -l review_elapsed (math (date +%s) - $review_start)
+            if test $review_elapsed -ge $phase_timeout
                 printf "\r                                                           \r"
                 echo " "(set_color red)"✗"(set_color normal)"  Review phase timed out after $phase_timeout seconds in iteration $iter"
                 for pane in $pane_ids
@@ -343,6 +345,7 @@ function review_auto
             echo ""
             echo " "(set_color brblack)$pr_url" · "(printf "%dm %ds" $total_dur_m $total_dur_s)(set_color normal)
             echo ""
+            rm -rf $session_dir
             return 0
         end
 
@@ -354,6 +357,7 @@ function review_auto
             echo ""
             echo " "(set_color brblack)$pr_url" · "(printf "%dm %ds" $total_dur_m $total_dur_s)(set_color normal)
             echo ""
+            rm -rf $session_dir
             return 0
         end
 

--- a/fish/.config/fish/functions/review_auto.fish
+++ b/fish/.config/fish/functions/review_auto.fish
@@ -178,8 +178,6 @@ function review_auto
         set -l iter_dir $session_dir/iter_$iter
         mkdir -p $iter_dir
 
-        set -l iter_start (date +%s)
-
         # On iteration 2+, recreate reviewer panes (same quadrant layout as initial)
         if test $iter -gt 1
             set -l pb (wezterm cli split-pane --pane-id $pane_0 --bottom)
@@ -251,7 +249,7 @@ function review_auto
                 end
             end
 
-            set -l total_el (math (date +%s) - $iter_start)
+            set -l total_el (math (date +%s) - $session_start)
             set -l total_m (math "floor($total_el / 60)")
             set -l total_s (math "$total_el % 60")
             set -l total_ts (printf "%d:%02d" $total_m $total_s)
@@ -309,7 +307,7 @@ function review_auto
         set -l triage_start (date +%s)
         set frame_idx 1
         while not test -f $triage_sentinel
-            set -l total_el (math (date +%s) - $iter_start)
+            set -l total_el (math (date +%s) - $session_start)
             set -l total_m (math "floor($total_el / 60)")
             set -l total_s (math "$total_el % 60")
             set -l total_ts (printf "%d:%02d" $total_m $total_s)
@@ -381,7 +379,7 @@ function review_auto
         set -l fix_start (date +%s)
         set frame_idx 1
         while not test -f $fix_sentinel
-            set -l total_el (math (date +%s) - $iter_start)
+            set -l total_el (math (date +%s) - $session_start)
             set -l total_m (math "floor($total_el / 60)")
             set -l total_s (math "$total_el % 60")
             set -l total_ts (printf "%d:%02d" $total_m $total_s)

--- a/fish/.config/fish/functions/review_auto.fish
+++ b/fish/.config/fish/functions/review_auto.fish
@@ -67,36 +67,36 @@ function review_auto
     echo "│  session: $session_dir"
     echo "└─────────────────────────────────────────────┘"
 
-    # --- split panes: orchestrator on top, reviewers on bottom ---
+    # --- split panes: orchestrator + Evelyn on top, rest on bottom ---
+    # Layout:
+    # ┌─────────────────────┬─────────────────────┐
+    # │   ORCHESTRATOR      │      Evelyn         │
+    # ├───────────┬─────────┴───────┬─────────────┤
+    # │ Vivian    │    Stella       │   Tiffany   │
+    # └───────────┴─────────────────┴─────────────┘
     set -l pane_0 $WEZTERM_PANE
     set -l pane_ids
 
-    set pane_ids (wezterm cli split-pane --pane-id $pane_0 --bottom --percent 70)
-    if test $num_panes -ge 2
-        set -a pane_ids (wezterm cli split-pane --pane-id $pane_ids[1] --right)
-    end
-    if test $num_panes -ge 3
-        set -a pane_ids (wezterm cli split-pane --pane-id $pane_ids[1] --right)
-    end
-    if test $num_panes -ge 4
-        set -a pane_ids (wezterm cli split-pane --pane-id $pane_ids[2] --right)
-    end
+    # Evelyn always goes top-right
+    set -l pane_evelyn (wezterm cli split-pane --pane-id $pane_0 --right)
+    set pane_ids $pane_evelyn
 
-    # pane_ids is now: [bottom-left, bottom-right, bottom-left-center, bottom-right-center]
-    # reorder to match reviewer indices 1..num_panes
-    switch $num_panes
-        case 1
-            # pane_ids = [p1]
-        case 2
-            # pane_ids = [p1, p2] — already correct
-        case 3
-            # splits: p1(left full), p2(right half of original), p3(right half of p1)
-            # actual order left→right: p1-remaining, p3, p2
-            set pane_ids $pane_ids[1] $pane_ids[3] $pane_ids[2]
-        case 4
-            # splits: p1(left half), p2(right half), p3(right of p1→center-left), p4(right of p2→center-right)
-            # actual order left→right: p1-remaining, p3, p2-remaining, p4
-            set pane_ids $pane_ids[1] $pane_ids[3] $pane_ids[2] $pane_ids[4]
+    if test $num_panes -ge 2
+        # Vivian: bottom-left (split orchestrator down)
+        set -l pane_vivian (wezterm cli split-pane --pane-id $pane_0 --bottom)
+        set -a pane_ids $pane_vivian
+
+        if test $num_panes -ge 3
+            # Stella: bottom-right (split Vivian right)
+            set -l pane_stella (wezterm cli split-pane --pane-id $pane_vivian --right)
+            set -a pane_ids $pane_stella
+
+            if test $num_panes -ge 4
+                # Tiffany: bottom-far-right (split Stella right)
+                set -l pane_tiffany (wezterm cli split-pane --pane-id $pane_stella --right)
+                set -a pane_ids $pane_tiffany
+            end
+        end
     end
 
     # --- main loop ---
@@ -147,7 +147,7 @@ function review_auto
         end
         echo "  All reviewers finished."
 
-        # --- triage phase ---
+        # --- triage phase (runs in Evelyn's pane) ---
         echo ""
         echo "───────────────────────────────────────────────"
         echo "  ROUND $round / $max_rounds — TRIAGE PHASE"
@@ -160,6 +160,7 @@ function review_auto
         end
         set -l file_list (string join ", " $review_files)
 
+        set -l triage_sentinel "$round_dir/.done_triage"
         set -l triage_prompt "You are a senior code-review triage agent. Read the review output files at: $file_list
 
 Your job:
@@ -169,9 +170,17 @@ Your job:
 - If a review file is empty or contains an error, skip it
 - If there are no real issues, output exactly the string: NO_ISSUES_FOUND
 - Format each real issue as: file path, line number, severity (critical/high/medium), and description
-- IMPORTANT: Write your final verdict to $round_dir/triage.md using the Write tool. Include NO_ISSUES_FOUND in that file if there are none."
+- IMPORTANT: Write your final verdict to $round_dir/triage.md using the Write tool. Include NO_ISSUES_FOUND in that file if there are none.
+- When completely done, run: touch $triage_sentinel"
 
-        cursor-agent --yolo --print --trust --model $triage_model -p "$triage_prompt"
+        set -l triage_cmd "cursor-agent --yolo --model $triage_model \"$triage_prompt\""
+        printf '%s\r' "$triage_cmd" | wezterm cli send-text --no-paste --pane-id $pane_ids[1]
+
+        echo "  Waiting for triage agent..."
+        while not test -f $triage_sentinel
+            sleep 5
+        end
+        echo "  Triage finished."
 
         # check triage result
         if grep -q "NO_ISSUES_FOUND" $round_dir/triage.md
@@ -194,15 +203,23 @@ Your job:
             return 0
         end
 
-        # --- fix phase ---
+        # --- fix phase (runs in Evelyn's pane) ---
         echo ""
         echo "───────────────────────────────────────────────"
         echo "  ROUND $round / $max_rounds — FIX PHASE"
         echo "───────────────────────────────────────────────"
 
-        set -l fix_prompt "You are a senior engineer. Read the triaged code-review issues at $round_dir/triage.md using the Read tool. Fix every issue listed. Do not fix anything not listed. After fixing, commit your changes with a clear message referencing what was fixed."
+        set -l fix_sentinel "$round_dir/.done_fix"
+        set -l fix_prompt "You are a senior engineer. Read the triaged code-review issues at $round_dir/triage.md using the Read tool. Fix every issue listed. Do not fix anything not listed. After fixing, commit your changes with a clear message referencing what was fixed. When completely done, run: touch $fix_sentinel"
 
-        cursor-agent --yolo --print --trust --model $fix_model -p "$fix_prompt"
+        set -l fix_cmd "cursor-agent --yolo --model $fix_model \"$fix_prompt\""
+        printf '%s\r' "$fix_cmd" | wezterm cli send-text --no-paste --pane-id $pane_ids[1]
+
+        echo "  Waiting for fix agent..."
+        while not test -f $fix_sentinel
+            sleep 5
+        end
+        echo "  Fix finished."
 
         set round (math $round + 1)
     end

--- a/fish/.config/fish/functions/review_auto.fish
+++ b/fish/.config/fish/functions/review_auto.fish
@@ -122,8 +122,8 @@ function review_auto
         mkdir -p $round_dir
 
         printf "\n\n"
-        echo "   "(set_color --bold)"review_auto"(set_color normal)"  "(set_color brblack)"·"(set_color normal)"  PR #"(set_color cyan)$pr_number(set_color normal)
-        echo "   "(set_color brblack)"$provider · $num_panes reviewers · round $round/$max_rounds"(set_color normal)
+        echo " "(set_color --bold)"review_auto"(set_color normal)"  "(set_color brblack)"·"(set_color normal)"  PR #"(set_color cyan)$pr_number(set_color normal)
+        echo " "(set_color brblack)"$provider · $num_panes reviewers · round $round/$max_rounds"(set_color normal)
         echo ""
         set -l round_start (date +%s)
 
@@ -178,7 +178,7 @@ function review_auto
             set -l mins (math "floor($elapsed / 60)")
             set -l secs (math "$elapsed % 60")
             set -l time_str (printf "%d:%02d" $mins $secs)
-            printf "\r   %s%s%s  review  %s %s%s%s" $dim $spinner_frames[$frame_idx] $reset "$status_line" $dim $time_str $reset
+            printf "\r %s%s%s  review  %s %s%s%s" $dim $spinner_frames[$frame_idx] $reset "$status_line" $dim $time_str $reset
 
             if test $done_count -ge $num_panes
                 break
@@ -192,7 +192,7 @@ function review_auto
         set -l secs (math "$elapsed % 60")
         set -l time_str (printf "%d:%02d" $mins $secs)
         printf "\r                                                           \r"
-        echo "   "(set_color white)"●"(set_color normal)"  review  $status_line"(set_color brblack)"$time_str"(set_color normal)
+        echo " "(set_color white)"●"(set_color normal)"  review  $status_line"(set_color brblack)"$time_str"(set_color normal)
 
         # kill reviewer panes and create fresh pane for triage/fix
         for pane in $pane_ids
@@ -220,7 +220,7 @@ function review_auto
             set -l mins (math "floor($elapsed / 60)")
             set -l secs (math "$elapsed % 60")
             set -l time_str (printf "%d:%02d" $mins $secs)
-            printf "\r   %s%s%s  triage  %s%s%s" $dim $spinner_frames[$frame_idx] $reset $dim $time_str $reset
+            printf "\r %s%s%s  triage  %s%s%s" $dim $spinner_frames[$frame_idx] $reset $dim $time_str $reset
             set frame_idx (math "$frame_idx % 10 + 1")
             sleep 0.05 # ~20 FPS for smooth spinner animation
         end
@@ -229,17 +229,17 @@ function review_auto
         set -l secs (math "$elapsed % 60")
         set -l time_str (printf "%d:%02d" $mins $secs)
         printf "\r                                                           \r"
-        echo "   "(set_color white)"●"(set_color normal)"  triage  "(set_color brblack)"$time_str"(set_color normal)
+        echo " "(set_color white)"●"(set_color normal)"  triage  "(set_color brblack)"$time_str"(set_color normal)
 
         # check triage result - must be on its own line to avoid false matches
         if grep -qx NO_ISSUES_FOUND $round_dir/triage.md 2>/dev/null
-            echo "   "(set_color green)"●"(set_color normal)"  "(set_color --bold)"clean"(set_color normal)" "(set_color brblack)"— no issues found"(set_color normal)
+            echo " "(set_color green)"●"(set_color normal)"  "(set_color --bold)"clean"(set_color normal)" "(set_color brblack)"— no issues found"(set_color normal)
             echo ""
             return 0
         end
 
         if test "$dry_run" = true
-            echo "   "(set_color yellow)"●"(set_color normal)"  "(set_color --bold)"dry run"(set_color normal)" "(set_color brblack)"— issues found, skipping fix"(set_color normal)
+            echo " "(set_color yellow)"●"(set_color normal)"  "(set_color --bold)"dry run"(set_color normal)" "(set_color brblack)"— issues found, skipping fix"(set_color normal)
             echo ""
             return 0
         end
@@ -261,7 +261,7 @@ function review_auto
             set -l mins (math "floor($elapsed / 60)")
             set -l secs (math "$elapsed % 60")
             set -l time_str (printf "%d:%02d" $mins $secs)
-            printf "\r   %s%s%s  fix  %s%s%s" $dim $spinner_frames[$frame_idx] $reset $dim $time_str $reset
+            printf "\r %s%s%s  fix  %s%s%s" $dim $spinner_frames[$frame_idx] $reset $dim $time_str $reset
             set frame_idx (math "$frame_idx % 10 + 1")
             sleep 0.05 # ~20 FPS for smooth spinner animation
         end
@@ -270,7 +270,7 @@ function review_auto
         set -l secs (math "$elapsed % 60")
         set -l time_str (printf "%d:%02d" $mins $secs)
         printf "\r                                                           \r"
-        echo "   "(set_color white)"●"(set_color normal)"  fix  "(set_color brblack)"$time_str"(set_color normal)
+        echo " "(set_color white)"●"(set_color normal)"  fix  "(set_color brblack)"$time_str"(set_color normal)
 
         # kill work pane before next round
         wezterm cli kill-pane --pane-id $work_pane 2>/dev/null
@@ -279,7 +279,7 @@ function review_auto
     end
 
     echo ""
-    echo "   "(set_color red)"●"(set_color normal)"  "(set_color --bold)"max rounds"(set_color normal)" "(set_color brblack)"— review manually"(set_color normal)
+    echo " "(set_color red)"●"(set_color normal)"  "(set_color --bold)"max rounds"(set_color normal)" "(set_color brblack)"— review manually"(set_color normal)
     echo ""
     return 1
 end

--- a/fish/.config/fish/functions/review_auto.fish
+++ b/fish/.config/fish/functions/review_auto.fish
@@ -207,7 +207,7 @@ IMPORTANT - Write your verdict to $round_dir/triage.md:
 - If there are NO real issues: write ONLY the text 'NO_ISSUES_FOUND' (nothing else, just that one line)
 - If there ARE real issues: write each issue with file path, line number, severity (critical/high/medium), and description. Do NOT include the string NO_ISSUES_FOUND anywhere." > $triage_prompt_file
 
-        set -l triage_cmd "cursor-agent --yolo --model $triage_model -p (cat $triage_prompt_file); touch $triage_sentinel"
+        set -l triage_cmd "cursor-agent --yolo --model $triage_model -p \"(cat $triage_prompt_file)\"; touch $triage_sentinel"
         printf '%s\r' "$triage_cmd" | wezterm cli send-text --no-paste --pane-id $work_pane
 
         set frame_idx 1
@@ -250,7 +250,7 @@ IMPORTANT - Write your verdict to $round_dir/triage.md:
         set -l fix_prompt_file "$round_dir/fix_prompt.txt"
         echo "You are a senior engineer. Read the triaged code-review issues at $round_dir/triage.md using the Read tool. Fix every issue listed. Do not fix anything not listed. After fixing, commit your changes with a clear message referencing what was fixed." > $fix_prompt_file
 
-        set -l fix_cmd "cursor-agent --yolo --model $fix_model -p (cat $fix_prompt_file); touch $fix_sentinel"
+        set -l fix_cmd "cursor-agent --yolo --model $fix_model -p \"(cat $fix_prompt_file)\"; touch $fix_sentinel"
         printf '%s\r' "$fix_cmd" | wezterm cli send-text --no-paste --pane-id $work_pane
 
         set frame_idx 1

--- a/fish/.config/fish/functions/review_auto.fish
+++ b/fish/.config/fish/functions/review_auto.fish
@@ -178,7 +178,7 @@ function review_auto
             set -l mins (math "floor($elapsed / 60)")
             set -l secs (math "$elapsed % 60")
             set -l time_str (printf "%d:%02d" $mins $secs)
-            printf "\r %s%s%s  Review (%s/%s)  %s %s%s%s" $dim $spinner_frames[$frame_idx] $reset $round $max_rounds "$status_line" $dim $time_str $reset
+            printf "\r %s%s%s  Review %s(%s/%s)%s  %s %s%s%s" $dim $spinner_frames[$frame_idx] $reset $dim $round $max_rounds $reset "$status_line" $dim $time_str $reset
 
             if test $done_count -ge $num_panes
                 break
@@ -200,7 +200,7 @@ function review_auto
         set -l work_pane (wezterm cli split-pane --pane-id $pane_0 --right)
 
         printf "\r                                                           \r"
-        echo " "(set_color green)"✔"(set_color normal)"  Review ($round/$max_rounds)  $status_line"(set_color brblack)"$time_str"(set_color normal)
+        echo " "(set_color green)"✔"(set_color normal)"  Review "(set_color brblack)"($round/$max_rounds)"(set_color normal)"  $status_line"(set_color brblack)"$time_str"(set_color normal)
 
         # --- triage phase ---
         set -l review_files
@@ -230,26 +230,31 @@ function review_auto
         set -l mins (math "floor($elapsed / 60)")
         set -l secs (math "$elapsed % 60")
         set -l time_str (printf "%d:%02d" $mins $secs)
+
+        # kill triage pane and create fresh one before printing
+        # (pane resize happens here, before any output)
+        wezterm cli kill-pane --pane-id $work_pane &>/dev/null
+        set work_pane (wezterm cli split-pane --pane-id $pane_0 --right)
+
         printf "\r                                                           \r"
         echo " "(set_color green)"✔"(set_color normal)"  Triage  "(set_color brblack)"$time_str"(set_color normal)
 
         # check triage result - must be on its own line to avoid false matches
         if grep -qx NO_ISSUES_FOUND $round_dir/triage.md 2>/dev/null
+            wezterm cli kill-pane --pane-id $work_pane &>/dev/null
             echo " "(set_color green)"●"(set_color normal)"  "(set_color --bold)"clean"(set_color normal)" "(set_color brblack)"— no issues found"(set_color normal)
             echo ""
             return 0
         end
 
         if test "$dry_run" = true
+            wezterm cli kill-pane --pane-id $work_pane &>/dev/null
             echo " "(set_color yellow)"●"(set_color normal)"  "(set_color --bold)"dry run"(set_color normal)" "(set_color brblack)"— issues found, skipping fix"(set_color normal)
             echo ""
             return 0
         end
 
-        # --- fix phase ---
-        # kill triage pane and create fresh one for fix
-        wezterm cli kill-pane --pane-id $work_pane &>/dev/null
-        set work_pane (wezterm cli split-pane --pane-id $pane_0 --right)
+        # --- fix phase (work pane already created above) ---
 
         set -l fix_sentinel "$round_dir/.done_fix"
         set -l fix_prompt "Read the triaged code-review issues at $round_dir/triage.md using the Read tool. Fix every issue listed. Do not fix anything not listed. After fixing, commit your changes with a clear message referencing what was fixed, then push to the remote branch with git push. Then use the /pr skill to update the PR title and description. When completely done, run this shell command: touch $fix_sentinel"

--- a/fish/.config/fish/functions/review_auto.fish
+++ b/fish/.config/fish/functions/review_auto.fish
@@ -40,11 +40,11 @@ function review_auto
 
     set -l review_model gpt-5.4-high
     set -l triage_model gpt-5.4-high
-    set -l fix_model claude-4.6-opus
+    set -l fix_model claude-4.6-opus-high
     switch $provider
         case anthropic
-            set review_model claude-4.6-opus
-            set triage_model claude-4.6-opus
+            set review_model claude-4.6-opus-high
+            set triage_model claude-4.6-opus-high
         case openai
             set fix_model gpt-5.4-high
     end

--- a/fish/.config/fish/functions/review_auto.fish
+++ b/fish/.config/fish/functions/review_auto.fish
@@ -61,11 +61,26 @@ function review_auto
         "You are Vivian. Use the local review skill to review PR #$pr_number in read-only mode and follow its exact response format." \
         "You are Stella. Use the local review skill to review PR #$pr_number in read-only mode and follow its exact response format. Focus on dead code, unused imports, and unreachable code paths."
 
-    echo "┌─────────────────────────────────────────────┐"
-    echo "│  review_auto — PR #$pr_number"
-    echo "│  provider: $provider | panes: $num_panes | max rounds: $max_rounds"
-    echo "│  session: $session_dir"
-    echo "└─────────────────────────────────────────────┘"
+    # --- beautiful header ---
+    set -l dim (set_color brblack)
+    set -l reset (set_color normal)
+    set -l bold (set_color --bold)
+    set -l cyan (set_color cyan)
+    set -l green (set_color green)
+    set -l yellow (set_color yellow)
+    set -l magenta (set_color magenta)
+    set -l red (set_color red)
+
+    echo ""
+    echo "$dim───────────────────────────────────────────────────$reset"
+    echo ""
+    echo "  $bold review_auto$reset  $dim·$reset  PR #$cyan$pr_number$reset"
+    echo ""
+    echo "  $dim provider$reset   $provider"
+    echo "  $dim reviewers$reset  $num_panes"
+    echo "  $dim rounds$reset     $max_rounds max"
+    echo ""
+    echo "$dim───────────────────────────────────────────────────$reset"
 
     # --- split panes: 4 quadrants (orchestrator + 3 reviewers) ---
     # Layout:
@@ -103,9 +118,11 @@ function review_auto
         mkdir -p $round_dir
 
         echo ""
-        echo "═══════════════════════════════════════════════"
-        echo "  ROUND $round / $max_rounds — REVIEW PHASE"
-        echo "═══════════════════════════════════════════════"
+        echo ""
+        echo "  $bold ROUND $round$reset$dim / $max_rounds$reset"
+        echo ""
+        echo "  $magenta● REVIEW$reset  $dim────────────────────────────────────$reset"
+        echo ""
 
         # clean sentinel files and kill any lingering agents from previous round
         for j in (seq $num_panes)
@@ -127,28 +144,40 @@ function review_auto
             printf '%s\r' "$cmd" | wezterm cli send-text --no-paste --pane-id $pane_ids[$j]
         end
 
-        # poll for all reviewers to finish
-        echo "  Waiting for $num_panes reviewer(s)..."
+        # poll for all reviewers to finish with animated spinner
+        set -l spinner_frames "⠋" "⠙" "⠹" "⠸" "⠼" "⠴" "⠦" "⠧" "⠇" "⠏"
+        set -l frame_idx 1
         while true
             set -l done_count 0
+            set -l status_line ""
             for j in (seq $num_panes)
-                set -l name (string lower $names[$j])
-                if test -f $round_dir/.done_$name
+                set -l name $names[$j]
+                set -l name_lower (string lower $name)
+                if test -f $round_dir/.done_$name_lower
                     set done_count (math $done_count + 1)
+                    set status_line "$status_line $green✓$reset $dim$name$reset  "
+                else
+                    set status_line "$status_line $yellow○$reset $name  "
                 end
             end
+            
+            printf "\r  $dim$spinner_frames[$frame_idx]$reset  $status_line"
+            
             if test $done_count -ge $num_panes
                 break
             end
-            sleep 5
+            
+            set frame_idx (math "$frame_idx % 10 + 1")
+            sleep 0.5
         end
-        echo "  All reviewers finished."
+        echo ""
+        echo ""
+        echo "  $green✓$reset  All reviewers complete"
 
         # --- triage phase (runs in Evelyn's pane) ---
         echo ""
-        echo "───────────────────────────────────────────────"
-        echo "  ROUND $round / $max_rounds — TRIAGE PHASE"
-        echo "───────────────────────────────────────────────"
+        echo "  $cyan● TRIAGE$reset  $dim────────────────────────────────────$reset"
+        echo ""
 
         set -l review_files
         for j in (seq $num_panes)
@@ -173,38 +202,51 @@ Your job:
         set -l triage_cmd "cursor-agent --yolo --model $triage_model \"$triage_prompt\""
         printf '%s\r' "$triage_cmd" | wezterm cli send-text --no-paste --pane-id $pane_ids[1]
 
-        echo "  Waiting for triage agent..."
+        set frame_idx 1
         while not test -f $triage_sentinel
-            sleep 5
+            printf "\r  $dim$spinner_frames[$frame_idx]$reset  Triaging reviews..."
+            set frame_idx (math "$frame_idx % 10 + 1")
+            sleep 0.5
         end
-        echo "  Triage finished."
+        echo ""
+        echo ""
+        echo "  $green✓$reset  Triage complete"
 
         # check triage result
         if grep -q "NO_ISSUES_FOUND" $round_dir/triage.md
             echo ""
-            echo "┌─────────────────────────────────────────────┐"
-            echo "│  CLEAN — no real issues found in round $round"
-            echo "│  PR #$pr_number is good to go."
-            echo "│  Session: $session_dir"
-            echo "└─────────────────────────────────────────────┘"
+            echo ""
+            echo "$dim───────────────────────────────────────────────────$reset"
+            echo ""
+            echo "  $green●$reset  $bold PR #$pr_number is clean$reset"
+            echo ""
+            echo "  $dim No real issues found in round $round.$reset"
+            echo "  $dim Session: $session_dir$reset"
+            echo ""
+            echo "$dim───────────────────────────────────────────────────$reset"
+            echo ""
             return 0
         end
 
         if test "$dry_run" = true
             echo ""
-            echo "┌─────────────────────────────────────────────┐"
-            echo "│  DRY RUN — issues found but skipping fix"
-            echo "│  Triage output: $round_dir/triage.md"
-            echo "│  Session: $session_dir"
-            echo "└─────────────────────────────────────────────┘"
+            echo ""
+            echo "$dim───────────────────────────────────────────────────$reset"
+            echo ""
+            echo "  $yellow●$reset  $bold Dry run complete$reset"
+            echo ""
+            echo "  $dim Issues found but skipping fix.$reset"
+            echo "  $dim Triage: $round_dir/triage.md$reset"
+            echo ""
+            echo "$dim───────────────────────────────────────────────────$reset"
+            echo ""
             return 0
         end
 
         # --- fix phase (runs in Evelyn's pane) ---
         echo ""
-        echo "───────────────────────────────────────────────"
-        echo "  ROUND $round / $max_rounds — FIX PHASE"
-        echo "───────────────────────────────────────────────"
+        echo "  $yellow● FIX$reset  $dim──────────────────────────────────────$reset"
+        echo ""
 
         set -l fix_sentinel "$round_dir/.done_fix"
         set -l fix_prompt "You are a senior engineer. Read the triaged code-review issues at $round_dir/triage.md using the Read tool. Fix every issue listed. Do not fix anything not listed. After fixing, commit your changes with a clear message referencing what was fixed. When completely done, run: touch $fix_sentinel"
@@ -212,20 +254,30 @@ Your job:
         set -l fix_cmd "cursor-agent --yolo --model $fix_model \"$fix_prompt\""
         printf '%s\r' "$fix_cmd" | wezterm cli send-text --no-paste --pane-id $pane_ids[1]
 
-        echo "  Waiting for fix agent..."
+        set frame_idx 1
         while not test -f $fix_sentinel
-            sleep 5
+            printf "\r  $dim$spinner_frames[$frame_idx]$reset  Applying fixes..."
+            set frame_idx (math "$frame_idx % 10 + 1")
+            sleep 0.5
         end
-        echo "  Fix finished."
+        echo ""
+        echo ""
+        echo "  $green✓$reset  Fixes applied"
 
         set round (math $round + 1)
     end
 
     echo ""
-    echo "┌─────────────────────────────────────────────┐"
-    echo "│  MAX ROUNDS ($max_rounds) reached for PR #$pr_number"
-    echo "│  Review the last round's output manually."
-    echo "│  Session: $session_dir"
-    echo "└─────────────────────────────────────────────┘"
+    echo ""
+    echo "$dim───────────────────────────────────────────────────$reset"
+    echo ""
+    echo "  $red●$reset  $bold Max rounds reached$reset"
+    echo ""
+    echo "  $dim Completed $max_rounds rounds for PR #$pr_number.$reset"
+    echo "  $dim Review the last round's output manually.$reset"
+    echo "  $dim Session: $session_dir$reset"
+    echo ""
+    echo "$dim───────────────────────────────────────────────────$reset"
+    echo ""
     return 1
 end

--- a/fish/.config/fish/functions/review_auto.fish
+++ b/fish/.config/fish/functions/review_auto.fish
@@ -336,7 +336,7 @@ function review_auto
         echo " "(set_color green)"✔"(set_color normal)" Triaged"
 
         # check triage result - compare trimmed entire file to exact string
-        set -l _triage_content (string trim (cat $round_dir/triage.md 2>/dev/null))
+        set -l _triage_content (cat $round_dir/triage.md 2>/dev/null | string trim)
         if test "$_triage_content" = NO_ISSUES_FOUND
             wezterm cli kill-pane --pane-id $work_pane &>/dev/null
             echo " "(set_color green)"✔"(set_color normal)" No issues found"

--- a/fish/.config/fish/functions/review_auto.fish
+++ b/fish/.config/fish/functions/review_auto.fish
@@ -205,11 +205,9 @@ Your job:
 
 IMPORTANT - Write your verdict to $round_dir/triage.md:
 - If there are NO real issues: write ONLY the text 'NO_ISSUES_FOUND' (nothing else, just that one line)
-- If there ARE real issues: write each issue with file path, line number, severity (critical/high/medium), and description. Do NOT include the string NO_ISSUES_FOUND anywhere.
+- If there ARE real issues: write each issue with file path, line number, severity (critical/high/medium), and description. Do NOT include the string NO_ISSUES_FOUND anywhere." > $triage_prompt_file
 
-When completely done, run: touch $triage_sentinel" > $triage_prompt_file
-
-        set -l triage_cmd "cursor-agent --yolo --model $triage_model \"Read the prompt at $triage_prompt_file and follow its instructions exactly.\""
+        set -l triage_cmd "cursor-agent --yolo --model $triage_model -p (cat $triage_prompt_file); touch $triage_sentinel"
         printf '%s\r' "$triage_cmd" | wezterm cli send-text --no-paste --pane-id $work_pane
 
         set frame_idx 1
@@ -244,15 +242,15 @@ When completely done, run: touch $triage_sentinel" > $triage_prompt_file
         end
 
         # --- fix phase ---
-        # send ctrl-c to kill triage agent, then start fix
-        printf '\x03' | wezterm cli send-text --no-paste --pane-id $work_pane
-        sleep 1
+        # kill triage pane and create fresh one for fix
+        wezterm cli kill-pane --pane-id $work_pane 2>/dev/null
+        set work_pane (wezterm cli split-pane --pane-id $pane_0 --right)
 
         set -l fix_sentinel "$round_dir/.done_fix"
         set -l fix_prompt_file "$round_dir/fix_prompt.txt"
-        echo "You are a senior engineer. Read the triaged code-review issues at $round_dir/triage.md using the Read tool. Fix every issue listed. Do not fix anything not listed. After fixing, commit your changes with a clear message referencing what was fixed. When completely done, run: touch $fix_sentinel" > $fix_prompt_file
+        echo "You are a senior engineer. Read the triaged code-review issues at $round_dir/triage.md using the Read tool. Fix every issue listed. Do not fix anything not listed. After fixing, commit your changes with a clear message referencing what was fixed." > $fix_prompt_file
 
-        set -l fix_cmd "cursor-agent --yolo --model $fix_model \"Read the prompt at $fix_prompt_file and follow its instructions exactly.\""
+        set -l fix_cmd "cursor-agent --yolo --model $fix_model -p (cat $fix_prompt_file); touch $fix_sentinel"
         printf '%s\r' "$fix_cmd" | wezterm cli send-text --no-paste --pane-id $work_pane
 
         set frame_idx 1
@@ -273,8 +271,6 @@ When completely done, run: touch $triage_sentinel" > $triage_prompt_file
         echo "   "(set_color white)"●"(set_color normal)"  fix  "(set_color brblack)"$time_str"(set_color normal)
         
         # kill work pane before next round
-        printf '\x03' | wezterm cli send-text --no-paste --pane-id $work_pane
-        sleep 1
         wezterm cli kill-pane --pane-id $work_pane 2>/dev/null
 
         set round (math $round + 1)

--- a/fish/.config/fish/functions/review_auto.fish
+++ b/fish/.config/fish/functions/review_auto.fish
@@ -73,9 +73,11 @@ function review_auto
 
     set -l white (set_color white)
     
-    echo ""
-    echo "   $bold review_auto$reset  $dim·$reset  PR #$cyan$pr_number$reset"
-    echo "   $dim$provider · $num_panes reviewers · $max_rounds rounds max$reset"
+    printf "\n\n"
+    set -l header1 "   "(set_color --bold)"review_auto"(set_color normal)"  "(set_color brblack)"·"(set_color normal)"  PR #"(set_color cyan)$pr_number(set_color normal)
+    set -l header2 "   "(set_color brblack)$provider" · "$num_panes" reviewers · "$max_rounds" rounds max"(set_color normal)
+    echo $header1
+    echo $header2
     echo ""
 
     # --- split panes: 4 quadrants (orchestrator + 3 reviewers) ---

--- a/fish/.config/fish/functions/review_auto.fish
+++ b/fish/.config/fish/functions/review_auto.fish
@@ -136,6 +136,7 @@ function review_auto
         echo "Failed to create Stella pane (split-pane returned empty ID)"
         wezterm cli kill-pane --pane-id $pane_evelyn &>/dev/null
         wezterm cli kill-pane --pane-id $pane_bottom &>/dev/null
+        rm -rf $session_dir
         return 1
     end
     # pane_bottom is now Vivian (bottom-left)

--- a/fish/.config/fish/functions/review_auto.fish
+++ b/fish/.config/fish/functions/review_auto.fish
@@ -157,7 +157,11 @@ function review_auto
     printf "\n\n"
     set -l pr_label "PR #$pr_number"
     if test -n "$pr_title"
-        set -l max_len 40
+        # " review_auto · " = 16 chars prefix, leave 2 for padding
+        set -l max_len (math $COLUMNS - 18)
+        if test $max_len -lt 20
+            set max_len 20
+        end
         if test (string length "$pr_title") -gt $max_len
             set pr_label (string sub -l $max_len "$pr_title")"…"
         else

--- a/fish/.config/fish/functions/review_auto.fish
+++ b/fish/.config/fish/functions/review_auto.fish
@@ -121,14 +121,24 @@ function review_auto
 
         set -l round_start (date +%s)
 
-        # clean sentinel files and kill any lingering agents from previous round
+        # On round 2+, recreate reviewer panes (they were killed after the previous review phase)
+        if test $round -gt 1
+            set pane_ids
+            if test $num_panes -ge 1
+                set -a pane_ids (wezterm cli split-pane --pane-id $pane_0 --right)
+            end
+            if test $num_panes -ge 2
+                set -a pane_ids (wezterm cli split-pane --pane-id $pane_0 --bottom)
+            end
+            if test $num_panes -ge 3
+                set -a pane_ids (wezterm cli split-pane --pane-id $pane_ids[2] --right)
+            end
+        end
+
+        # clean sentinel files
         for j in (seq $num_panes)
             set -l name (string lower $names[$j])
             rm -f $round_dir/.done_$name
-            if test $round -gt 1
-                printf '\x03' | wezterm cli send-text --no-paste --pane-id $pane_ids[$j]
-                sleep 1
-            end
         end
 
         # dispatch review agents to panes

--- a/fish/.config/fish/functions/review_auto.fish
+++ b/fish/.config/fish/functions/review_auto.fish
@@ -115,29 +115,33 @@ function review_auto
         set pane_ids $pane_evelyn
     end
 
+    # --- header (printed once) ---
+    printf "\n\n"
+    echo " "(set_color --bold)"review_auto"(set_color normal)" "(set_color brblack)"·"(set_color normal)" PR #"(set_color cyan)$pr_number(set_color normal)
+    echo " "(set_color brblack)"$provider · $num_panes reviewers"(set_color normal)
+    echo ""
+
     # --- main loop ---
     set -l round 1
     while test $round -le $max_rounds
         set -l round_dir $session_dir/round_$round
         mkdir -p $round_dir
 
-        printf "\n\n"
-        echo " "(set_color --bold)"review_auto"(set_color normal)"  "(set_color brblack)"·"(set_color normal)"  PR #"(set_color cyan)$pr_number(set_color normal)
-        echo " "(set_color brblack)"$provider · $num_panes reviewers"(set_color normal)
-        echo ""
         set -l round_start (date +%s)
 
-        # On round 2+, recreate reviewer panes (they were killed after the previous review phase)
+        # On round 2+, recreate reviewer panes (same quadrant layout as initial)
         if test $round -gt 1
-            set pane_ids
-            if test $num_panes -ge 1
-                set -a pane_ids (wezterm cli split-pane --pane-id $pane_0 --right)
+            set -l pb (wezterm cli split-pane --pane-id $pane_0 --bottom)
+            set -l pe (wezterm cli split-pane --pane-id $pane_0 --right)
+            set -l ps (wezterm cli split-pane --pane-id $pb --right)
+            set pane_ids $pe $pb $ps
+            if test $num_panes -lt 3
+                wezterm cli kill-pane --pane-id $ps &>/dev/null
+                set pane_ids $pe $pb
             end
-            if test $num_panes -ge 2
-                set -a pane_ids (wezterm cli split-pane --pane-id $pane_0 --bottom)
-            end
-            if test $num_panes -ge 3
-                set -a pane_ids (wezterm cli split-pane --pane-id $pane_ids[2] --right)
+            if test $num_panes -lt 2
+                wezterm cli kill-pane --pane-id $pb &>/dev/null
+                set pane_ids $pe
             end
         end
 

--- a/fish/.config/fish/functions/review_auto.fish
+++ b/fish/.config/fish/functions/review_auto.fish
@@ -211,7 +211,7 @@ function review_auto
         set -l file_list (string join ", " $review_files)
 
         set -l triage_sentinel "$round_dir/.done_triage"
-        set -l triage_prompt "You are a senior code-review triage agent. Read the review output files at: $file_list. Read all review files using the Read tool. Filter out nitpicks, style-only comments, and false positives. Identify ONLY real bugs, logic errors, security vulnerabilities, or missing error handling. If a review file is empty or contains an error, skip it. Write your verdict to $round_dir/triage.md. If there are NO real issues: write ONLY the text NO_ISSUES_FOUND (nothing else, just that one line). If there ARE real issues: write each issue with file path, line number, severity (critical/high/medium), and description. Do NOT include the string NO_ISSUES_FOUND anywhere. When completely done, run this shell command: touch $triage_sentinel"
+        set -l triage_prompt "You are a code-review triage agent. Read the review output files at: $file_list. Read all review files using the Read tool. Filter out nitpicks, style-only comments, and false positives. Identify ONLY real bugs, logic errors, security vulnerabilities, or missing error handling. If a review file is empty or contains an error, skip it. Write your verdict to $round_dir/triage.md. If there are NO real issues: write ONLY the text NO_ISSUES_FOUND (nothing else, just that one line). If there ARE real issues: write each issue with file path, line number, severity (critical/high/medium), and description. Do NOT include the string NO_ISSUES_FOUND anywhere. When completely done, run this shell command: touch $triage_sentinel"
 
         set -l triage_cmd "cursor-agent --yolo --model $triage_model \"$triage_prompt\""
         printf '%s\r' "$triage_cmd" | wezterm cli send-text --no-paste --pane-id $work_pane
@@ -252,7 +252,7 @@ function review_auto
         set work_pane (wezterm cli split-pane --pane-id $pane_0 --right)
 
         set -l fix_sentinel "$round_dir/.done_fix"
-        set -l fix_prompt "You are a senior engineer. Read the triaged code-review issues at $round_dir/triage.md using the Read tool. Fix every issue listed. Do not fix anything not listed. After fixing, commit your changes with a clear message referencing what was fixed, then push to the remote branch with git push. Then use the /pr skill to update the PR title and description. When completely done, run this shell command: touch $fix_sentinel"
+        set -l fix_prompt "Read the triaged code-review issues at $round_dir/triage.md using the Read tool. Fix every issue listed. Do not fix anything not listed. After fixing, commit your changes with a clear message referencing what was fixed, then push to the remote branch with git push. Then use the /pr skill to update the PR title and description. When completely done, run this shell command: touch $fix_sentinel"
 
         set -l fix_cmd "cursor-agent --yolo --model $fix_model \"$fix_prompt\""
         printf '%s\r' "$fix_cmd" | wezterm cli send-text --no-paste --pane-id $work_pane

--- a/fish/.config/fish/functions/review_auto.fish
+++ b/fish/.config/fish/functions/review_auto.fish
@@ -1,10 +1,11 @@
 function review_auto
-    # Usage: review_auto [--max-rounds N] [--provider openai|anthropic] [--panes 1-3] [--dry-run]
+    # Usage: review_auto [--max-rounds N] [--provider openai|anthropic] [--panes 1-3] [--timeout SECS] [--dry-run]
     # Uses --yolo so agents can run shell tools (gh cli, git, etc.) for PR inspection.
     # Default: 3 reviewers (Evelyn, Vivian, Stella) in 4-quadrant layout.
     set -l max_rounds 3
     set -l provider anthropic
     set -l num_panes 3
+    set -l phase_timeout 600
     set -l dry_run false
 
     set -l i 1
@@ -35,12 +36,27 @@ function review_auto
                     echo "Missing value for --panes"
                     return 1
                 end
+                if not string match -qr '^\d+$' -- $argv[$i]
+                    echo "Invalid --panes value: '$argv[$i]' (must be a positive integer)"
+                    return 1
+                end
                 set num_panes $argv[$i]
+            case --timeout
+                set i (math $i + 1)
+                if test $i -gt $argc
+                    echo "Missing value for --timeout"
+                    return 1
+                end
+                if not string match -qr '^\d+$' -- $argv[$i]; or test $argv[$i] -le 0
+                    echo "Invalid --timeout value: '$argv[$i]' (must be a positive integer in seconds)"
+                    return 1
+                end
+                set phase_timeout $argv[$i]
             case --dry-run
                 set dry_run true
             case '*'
                 echo "Unknown argument: $argv[$i]"
-                echo "Usage: review_auto [--max-rounds N] [--provider openai|anthropic] [--panes 1-3] [--dry-run]"
+                echo "Usage: review_auto [--max-rounds N] [--provider openai|anthropic] [--panes 1-3] [--timeout SECS] [--dry-run]"
                 return 1
         end
         set i (math $i + 1)
@@ -225,6 +241,15 @@ function review_auto
                 break
             end
 
+            if test $elapsed -ge $phase_timeout
+                printf "\r                                                           \r"
+                echo " "(set_color red)"✗"(set_color normal)"  Review phase timed out after $phase_timeout seconds in round $round"
+                for pane in $pane_ids
+                    wezterm cli kill-pane --pane-id $pane &>/dev/null
+                end
+                return 1
+            end
+
             set frame_idx (math "$frame_idx % 10 + 1")
             sleep 0.05 # ~20 FPS for smooth spinner animation
         end
@@ -239,6 +264,10 @@ function review_auto
             wezterm cli kill-pane --pane-id $pane &>/dev/null
         end
         set -l work_pane (wezterm cli split-pane --pane-id $pane_0 --right)
+        if test -z "$work_pane"
+            echo "Failed to create work pane after review phase in round $round"
+            return 1
+        end
 
         printf "\r                                                           \r"
         echo " "(set_color green)"✔"(set_color normal)"  Review "(set_color brblack)"($round/$max_rounds)"(set_color normal)"  $status_line"(set_color brblack)"$time_str"(set_color normal)
@@ -259,6 +288,7 @@ function review_auto
         set -l triage_cmd "cursor-agent --yolo --model $triage_model \"\$(cat $triage_prompt_file)\""
         printf '%s\r' "$triage_cmd" | wezterm cli send-text --no-paste --pane-id $work_pane
 
+        set -l triage_start (date +%s)
         set frame_idx 1
         while not test -f $triage_sentinel
             set -l elapsed (math (date +%s) - $round_start)
@@ -266,6 +296,15 @@ function review_auto
             set -l secs (math "$elapsed % 60")
             set -l time_str (printf "%d:%02d" $mins $secs)
             printf "\r %s%s%s  Triage  %s%s%s" $dim $spinner_frames[$frame_idx] $reset $dim $time_str $reset
+
+            set -l phase_elapsed (math (date +%s) - $triage_start)
+            if test $phase_elapsed -ge $phase_timeout
+                printf "\r                                                           \r"
+                echo " "(set_color red)"✗"(set_color normal)"  Triage phase timed out after $phase_timeout seconds in round $round"
+                wezterm cli kill-pane --pane-id $work_pane &>/dev/null
+                return 1
+            end
+
             set frame_idx (math "$frame_idx % 10 + 1")
             sleep 0.05 # ~20 FPS for smooth spinner animation
         end
@@ -278,6 +317,10 @@ function review_auto
         # (pane resize happens here, before any output)
         wezterm cli kill-pane --pane-id $work_pane &>/dev/null
         set work_pane (wezterm cli split-pane --pane-id $pane_0 --right)
+        if test -z "$work_pane"
+            echo "Failed to create work pane after triage phase in round $round"
+            return 1
+        end
 
         printf "\r                                                           \r"
         echo " "(set_color green)"✔"(set_color normal)"  Triage  "(set_color brblack)"$time_str"(set_color normal)
@@ -307,6 +350,7 @@ function review_auto
         set -l fix_cmd "cursor-agent --yolo --model $fix_model \"\$(cat $fix_prompt_file)\""
         printf '%s\r' "$fix_cmd" | wezterm cli send-text --no-paste --pane-id $work_pane
 
+        set -l fix_start (date +%s)
         set frame_idx 1
         while not test -f $fix_sentinel
             set -l elapsed (math (date +%s) - $round_start)
@@ -314,6 +358,15 @@ function review_auto
             set -l secs (math "$elapsed % 60")
             set -l time_str (printf "%d:%02d" $mins $secs)
             printf "\r %s%s%s  Fix  %s%s%s" $dim $spinner_frames[$frame_idx] $reset $dim $time_str $reset
+
+            set -l phase_elapsed (math (date +%s) - $fix_start)
+            if test $phase_elapsed -ge $phase_timeout
+                printf "\r                                                           \r"
+                echo " "(set_color red)"✗"(set_color normal)"  Fix phase timed out after $phase_timeout seconds in round $round"
+                wezterm cli kill-pane --pane-id $work_pane &>/dev/null
+                return 1
+            end
+
             set frame_idx (math "$frame_idx % 10 + 1")
             sleep 0.05 # ~20 FPS for smooth spinner animation
         end

--- a/fish/.config/fish/functions/review_auto.fish
+++ b/fish/.config/fish/functions/review_auto.fish
@@ -169,7 +169,7 @@ function review_auto
         end
     end
     echo " "(set_color --bold)"review_auto"(set_color normal)" "(set_color brblack)"·"(set_color normal)" "\e]8\;\;$pr_url\e\\(set_color white)$pr_label(set_color normal)\e]8\;\;\e\\
-    echo " "(set_color brblack)"$provider · $num_panes reviewers"(set_color normal)
+    echo " "(set_color brblack)"$provider · $num_panes reviewers · $max_iters max iterations"(set_color normal)
     echo ""
 
     # --- main loop ---
@@ -288,7 +288,7 @@ function review_auto
         end
 
         printf "\r                                                           \r"
-        echo " "(set_color green)"✔"(set_color normal)" Reviewed"
+        echo " "(set_color green)"✔"(set_color normal)" Reviewed "(set_color brblack)"($iter/$max_iters)"(set_color normal)
 
         # --- triage phase ---
         set -l review_files

--- a/fish/.config/fish/functions/review_auto.fish
+++ b/fish/.config/fish/functions/review_auto.fish
@@ -67,7 +67,9 @@ function review_auto
         return 1
     end
 
-    set -l pr_number (gh pr view --json number -q .number 2>/dev/null)
+    set -l pr_json (gh pr view --json number,url 2>/dev/null)
+    set -l pr_number (echo $pr_json | string match -r '"number":(\d+)' | tail -1)
+    set -l pr_url (echo $pr_json | string match -r '"url":"([^"]+)"' | tail -1)
     if test -z "$pr_number"
         echo "No PR found for current branch"
         return 1
@@ -330,12 +332,16 @@ function review_auto
             wezterm cli kill-pane --pane-id $work_pane &>/dev/null
             echo " "(set_color green)"●"(set_color normal)"  "(set_color --bold)"clean"(set_color normal)" "(set_color brblack)"— no issues found"(set_color normal)
             echo ""
+            echo " "(set_color brblack)$pr_url(set_color normal)
+            echo ""
             return 0
         end
 
         if test "$dry_run" = true
             wezterm cli kill-pane --pane-id $work_pane &>/dev/null
             echo " "(set_color yellow)"●"(set_color normal)"  "(set_color --bold)"dry run"(set_color normal)" "(set_color brblack)"— issues found, skipping fix"(set_color normal)
+            echo ""
+            echo " "(set_color brblack)$pr_url(set_color normal)
             echo ""
             return 0
         end
@@ -385,6 +391,8 @@ function review_auto
 
     echo ""
     echo " "(set_color red)"●"(set_color normal)"  "(set_color --bold)"max rounds"(set_color normal)" "(set_color brblack)"— review manually"(set_color normal)
+    echo ""
+    echo " "(set_color brblack)$pr_url(set_color normal)
     echo ""
     return 1
 end

--- a/fish/.config/fish/functions/review_auto.fish
+++ b/fish/.config/fish/functions/review_auto.fish
@@ -250,7 +250,7 @@ function review_auto
         set work_pane (wezterm cli split-pane --pane-id $pane_0 --right)
 
         set -l fix_sentinel "$round_dir/.done_fix"
-        set -l fix_prompt "You are a senior engineer. Read the triaged code-review issues at $round_dir/triage.md using the Read tool. Fix every issue listed. Do not fix anything not listed. After fixing, commit your changes with a clear message referencing what was fixed, then push to the remote branch with git push. When completely done, run this shell command: touch $fix_sentinel"
+        set -l fix_prompt "You are a senior engineer. Read the triaged code-review issues at $round_dir/triage.md using the Read tool. Fix every issue listed. Do not fix anything not listed. After fixing, commit your changes with a clear message referencing what was fixed, then push to the remote branch with git push. Then use the /pr skill to update the PR title and description. When completely done, run this shell command: touch $fix_sentinel"
 
         set -l fix_cmd "cursor-agent --yolo --model $fix_model \"$fix_prompt\""
         printf '%s\r' "$fix_cmd" | wezterm cli send-text --no-paste --pane-id $work_pane

--- a/fish/.config/fish/functions/review_auto.fish
+++ b/fish/.config/fish/functions/review_auto.fish
@@ -191,14 +191,16 @@ function review_auto
         set -l mins (math "floor($elapsed / 60)")
         set -l secs (math "$elapsed % 60")
         set -l time_str (printf "%d:%02d" $mins $secs)
-        printf "\r                                                           \r"
-        echo " "(set_color white)"●"(set_color normal)"  review  $status_line"(set_color brblack)"$time_str"(set_color normal)
 
-        # kill reviewer panes and create fresh pane for triage/fix
+        # kill reviewer panes and create fresh work pane before printing final status
+        # (pane resize happens here, before any output)
         for pane in $pane_ids
             wezterm cli kill-pane --pane-id $pane &>/dev/null
         end
         set -l work_pane (wezterm cli split-pane --pane-id $pane_0 --right)
+
+        printf "\r                                                           \r"
+        echo " "(set_color white)"●"(set_color normal)"  review  $status_line"(set_color brblack)"$time_str"(set_color normal)
 
         # --- triage phase ---
         set -l review_files

--- a/fish/.config/fish/functions/review_auto.fish
+++ b/fish/.config/fish/functions/review_auto.fish
@@ -226,25 +226,22 @@ Your job:
         set -l time_str (printf "%d:%02d" $mins $secs)
         printf "\r                                                           \r"
         echo "   "(set_color white)"●"(set_color normal)"  triage  "(set_color brblack)"$time_str"(set_color normal)
+        echo ""
 
         # check triage result
         if grep -q NO_ISSUES_FOUND $round_dir/triage.md 2>/dev/null
-            echo ""
             echo "   "(set_color green)"●"(set_color normal)"  "(set_color --bold)"clean"(set_color normal)" "(set_color brblack)"— no issues found"(set_color normal)
             echo ""
             return 0
         end
 
         if test "$dry_run" = true
-            echo ""
             echo "   "(set_color yellow)"●"(set_color normal)"  "(set_color --bold)"dry run"(set_color normal)" "(set_color brblack)"— issues found, skipping fix"(set_color normal)
             echo ""
             return 0
         end
 
         # --- fix phase ---
-        echo ""
-        
         # send ctrl-c to kill triage agent, then start fix
         printf '\x03' | wezterm cli send-text --no-paste --pane-id $work_pane
         sleep 1

--- a/fish/.config/fish/functions/review_auto.fish
+++ b/fish/.config/fish/functions/review_auto.fish
@@ -8,16 +8,29 @@ function review_auto
     set -l dry_run false
 
     set -l i 1
-    while test $i -le (count $argv)
+    set -l argc (count $argv)
+    while test $i -le $argc
         switch $argv[$i]
             case --max-rounds
                 set i (math $i + 1)
+                if test $i -gt $argc
+                    echo "Missing value for --max-rounds"
+                    return 1
+                end
                 set max_rounds $argv[$i]
             case --provider
                 set i (math $i + 1)
+                if test $i -gt $argc
+                    echo "Missing value for --provider"
+                    return 1
+                end
                 set provider (string lower $argv[$i])
             case --panes
                 set i (math $i + 1)
+                if test $i -gt $argc
+                    echo "Missing value for --panes"
+                    return 1
+                end
                 set num_panes $argv[$i]
             case --dry-run
                 set dry_run true
@@ -49,6 +62,9 @@ function review_auto
             set triage_model claude-4.6-opus-high
         case openai
             set fix_model gpt-5.4-high
+        case '*'
+            echo "Invalid provider: $provider (must be 'anthropic' or 'openai')"
+            return 1
     end
 
     set -l session_dir (mktemp -d /tmp/review_auto.XXXXXX)
@@ -64,14 +80,7 @@ function review_auto
     # --- beautiful header ---
     set -l dim (set_color brblack)
     set -l reset (set_color normal)
-    set -l bold (set_color --bold)
-    set -l cyan (set_color cyan)
     set -l green (set_color green)
-    set -l yellow (set_color yellow)
-    set -l magenta (set_color magenta)
-    set -l red (set_color red)
-
-    set -l white (set_color white)
 
     printf "\n"
     set -l header1 "   "(set_color --bold)"review_auto"(set_color normal)"  "(set_color brblack)"·"(set_color normal)"  PR #"(set_color cyan)$pr_number(set_color normal)
@@ -90,24 +99,16 @@ function review_auto
     set -l pane_0 $WEZTERM_PANE
     set -l pane_ids
 
-    # Create quadrants (same pattern as wez_quadrants.example.fish)
-    set -l pane_bottom_left (wezterm cli split-pane --pane-id $pane_0 --bottom)
-    set -l pane_bottom_right (wezterm cli split-pane --pane-id $pane_bottom_left --right)
-    set -l pane_top_right (wezterm cli split-pane --pane-id $pane_0 --right)
-
-    # pane_ids: [Evelyn (top-right), Vivian (bottom-left), Stella (bottom-right)]
-    set pane_ids $pane_top_right $pane_bottom_left $pane_bottom_right
-
-    # For fewer panes, kill unused ones
-    if test $num_panes -lt 3
-        wezterm cli kill-pane --pane-id $pane_bottom_right
+    # Create only the panes we need
+    if test $num_panes -ge 1
+        set -a pane_ids (wezterm cli split-pane --pane-id $pane_0 --right)
     end
-    if test $num_panes -lt 2
-        wezterm cli kill-pane --pane-id $pane_bottom_left
+    if test $num_panes -ge 2
+        set -a pane_ids (wezterm cli split-pane --pane-id $pane_0 --bottom)
     end
-
-    # Trim pane_ids to match num_panes
-    set pane_ids $pane_ids[1..$num_panes]
+    if test $num_panes -ge 3
+        set -a pane_ids (wezterm cli split-pane --pane-id $pane_ids[2] --right)
+    end
 
     # --- main loop ---
     set -l round 1
@@ -179,7 +180,7 @@ function review_auto
             end
             
             set frame_idx (math "$frame_idx % 10 + 1")
-            sleep 0.05
+            sleep 0.5
         end
         set -l elapsed (math (date +%s) - $round_start)
         set -l mins (math "floor($elapsed / 60)")
@@ -217,7 +218,7 @@ IMPORTANT - Write your verdict to $round_dir/triage.md:
 - If there are NO real issues: write ONLY the text 'NO_ISSUES_FOUND' (nothing else, just that one line)
 - If there ARE real issues: write each issue with file path, line number, severity (critical/high/medium), and description. Do NOT include the string NO_ISSUES_FOUND anywhere." > $triage_prompt_file
 
-        set -l triage_cmd "cursor-agent --yolo --model $triage_model -p \"(cat $triage_prompt_file)\"; touch $triage_sentinel"
+        set -l triage_cmd "cursor-agent --yolo --model $triage_model -p \"(cat $triage_prompt_file)\" && touch $triage_sentinel"
         printf '%s\r' "$triage_cmd" | wezterm cli send-text --no-paste --pane-id $work_pane
 
         set frame_idx 1
@@ -258,9 +259,9 @@ IMPORTANT - Write your verdict to $round_dir/triage.md:
 
         set -l fix_sentinel "$round_dir/.done_fix"
         set -l fix_prompt_file "$round_dir/fix_prompt.txt"
-        echo "You are a senior engineer. Read the triaged code-review issues at $round_dir/triage.md using the Read tool. Fix every issue listed. Do not fix anything not listed. After fixing, commit your changes with a clear message referencing what was fixed." > $fix_prompt_file
+        echo "You are a senior engineer. Read the triaged code-review issues at $round_dir/triage.md using the Read tool. Fix every issue listed. Do not fix anything not listed. After fixing, commit your changes with a clear message referencing what was fixed, then push to the remote branch (git push)." > $fix_prompt_file
 
-        set -l fix_cmd "cursor-agent --yolo --model $fix_model -p \"(cat $fix_prompt_file)\"; touch $fix_sentinel"
+        set -l fix_cmd "cursor-agent --yolo --model $fix_model -p \"(cat $fix_prompt_file)\" && touch $fix_sentinel"
         printf '%s\r' "$fix_cmd" | wezterm cli send-text --no-paste --pane-id $work_pane
 
         set frame_idx 1

--- a/fish/.config/fish/functions/review_auto.fish
+++ b/fish/.config/fish/functions/review_auto.fish
@@ -179,6 +179,13 @@ function review_auto
         echo "   "(set_color white)"●"(set_color normal)"  review  $status_line"(set_color brblack)"$time_str"(set_color normal)
         echo ""
 
+        # kill reviewer panes and create fresh pane for triage/fix
+        for pane in $pane_ids
+            wezterm cli kill-pane --pane-id $pane 2>/dev/null
+        end
+        set -l work_pane (wezterm cli split-pane --pane-id $pane_0 --right)
+
+        # --- triage phase ---
         set -l review_files
         for j in (seq $num_panes)
             set -l name (string lower $names[$j])
@@ -187,7 +194,8 @@ function review_auto
         set -l file_list (string join ", " $review_files)
 
         set -l triage_sentinel "$round_dir/.done_triage"
-        set -l triage_prompt "You are a senior code-review triage agent. Read the review output files at: $file_list
+        set -l triage_prompt_file "$round_dir/triage_prompt.txt"
+        echo "You are a senior code-review triage agent. Read the review output files at: $file_list
 
 Your job:
 - Read all review files using the Read tool
@@ -197,10 +205,10 @@ Your job:
 - If there are no real issues, output exactly the string: NO_ISSUES_FOUND
 - Format each real issue as: file path, line number, severity (critical/high/medium), and description
 - IMPORTANT: Write your final verdict to $round_dir/triage.md using the Write tool. Include NO_ISSUES_FOUND in that file if there are none.
-- When completely done, run: touch $triage_sentinel"
+- When completely done, run: touch $triage_sentinel" > $triage_prompt_file
 
-        set -l triage_cmd "cursor-agent --yolo --model $triage_model \"$triage_prompt\""
-        printf '%s\r' "$triage_cmd" | wezterm cli send-text --no-paste --pane-id $pane_ids[1]
+        set -l triage_cmd "cursor-agent --yolo --model $triage_model \"Read the prompt at $triage_prompt_file and follow its instructions exactly.\""
+        printf '%s\r' "$triage_cmd" | wezterm cli send-text --no-paste --pane-id $work_pane
 
         set frame_idx 1
         while not test -f $triage_sentinel
@@ -220,7 +228,7 @@ Your job:
         echo "   "(set_color white)"●"(set_color normal)"  triage  "(set_color brblack)"$time_str"(set_color normal)
 
         # check triage result
-        if grep -q NO_ISSUES_FOUND $round_dir/triage.md
+        if grep -q NO_ISSUES_FOUND $round_dir/triage.md 2>/dev/null
             echo ""
             echo "   "(set_color green)"●"(set_color normal)"  "(set_color --bold)"clean"(set_color normal)" "(set_color brblack)"— no issues found"(set_color normal)
             echo ""
@@ -234,14 +242,19 @@ Your job:
             return 0
         end
 
-        # --- fix phase (runs in Evelyn's pane) ---
+        # --- fix phase ---
         echo ""
+        
+        # send ctrl-c to kill triage agent, then start fix
+        printf '\x03' | wezterm cli send-text --no-paste --pane-id $work_pane
+        sleep 1
 
         set -l fix_sentinel "$round_dir/.done_fix"
-        set -l fix_prompt "You are a senior engineer. Read the triaged code-review issues at $round_dir/triage.md using the Read tool. Fix every issue listed. Do not fix anything not listed. After fixing, commit your changes with a clear message referencing what was fixed. When completely done, run: touch $fix_sentinel"
+        set -l fix_prompt_file "$round_dir/fix_prompt.txt"
+        echo "You are a senior engineer. Read the triaged code-review issues at $round_dir/triage.md using the Read tool. Fix every issue listed. Do not fix anything not listed. After fixing, commit your changes with a clear message referencing what was fixed. When completely done, run: touch $fix_sentinel" > $fix_prompt_file
 
-        set -l fix_cmd "cursor-agent --yolo --model $fix_model \"$fix_prompt\""
-        printf '%s\r' "$fix_cmd" | wezterm cli send-text --no-paste --pane-id $pane_ids[1]
+        set -l fix_cmd "cursor-agent --yolo --model $fix_model \"Read the prompt at $fix_prompt_file and follow its instructions exactly.\""
+        printf '%s\r' "$fix_cmd" | wezterm cli send-text --no-paste --pane-id $work_pane
 
         set frame_idx 1
         while not test -f $fix_sentinel
@@ -259,6 +272,11 @@ Your job:
         set -l time_str (printf "%d:%02d" $mins $secs)
         printf "\r                                                           \r"
         echo "   "(set_color white)"●"(set_color normal)"  fix  "(set_color brblack)"$time_str"(set_color normal)
+        
+        # kill work pane before next round
+        printf '\x03' | wezterm cli send-text --no-paste --pane-id $work_pane
+        sleep 1
+        wezterm cli kill-pane --pane-id $work_pane 2>/dev/null
 
         set round (math $round + 1)
     end

--- a/fish/.config/fish/functions/review_auto.fish
+++ b/fish/.config/fish/functions/review_auto.fish
@@ -72,15 +72,8 @@ function review_auto
     set -l red (set_color red)
 
     echo ""
-    echo "$dim───────────────────────────────────────────────────$reset"
+    echo "  $bold review_auto$reset $dim·$reset PR #$cyan$pr_number$reset $dim·$reset $provider $dim·$reset $num_panes reviewers $dim·$reset $max_rounds rounds"
     echo ""
-    echo "  $bold review_auto$reset  $dim·$reset  PR #$cyan$pr_number$reset"
-    echo ""
-    echo "  $dim provider$reset   $provider"
-    echo "  $dim reviewers$reset  $num_panes"
-    echo "  $dim rounds$reset     $max_rounds max"
-    echo ""
-    echo "$dim───────────────────────────────────────────────────$reset"
 
     # --- split panes: 4 quadrants (orchestrator + 3 reviewers) ---
     # Layout:
@@ -118,11 +111,7 @@ function review_auto
         mkdir -p $round_dir
 
         echo ""
-        echo ""
-        echo "  $bold ROUND $round$reset$dim / $max_rounds$reset"
-        echo ""
-        echo "  $magenta● REVIEW$reset  $dim────────────────────────────────────$reset"
-        echo ""
+        echo "  $magenta$bold round $round$reset$dim/$max_rounds$reset  $dim reviewing$reset"
 
         # clean sentinel files and kill any lingering agents from previous round
         for j in (seq $num_panes)
@@ -155,29 +144,25 @@ function review_auto
                 set -l name_lower (string lower $name)
                 if test -f $round_dir/.done_$name_lower
                     set done_count (math $done_count + 1)
-                    set status_line "$status_line $green✓$reset $dim$name$reset  "
+                    set status_line "$status_line$green$name$reset  "
                 else
-                    set status_line "$status_line $yellow○$reset $name  "
+                    set status_line "$status_line$dim$name$reset  "
                 end
             end
             
-            printf "\r  $dim$spinner_frames[$frame_idx]$reset  $status_line"
+            printf "\r  $dim$spinner_frames[$frame_idx]$reset $status_line"
             
             if test $done_count -ge $num_panes
                 break
             end
             
             set frame_idx (math "$frame_idx % 10 + 1")
-            sleep 0.08
+            sleep 0.05
         end
-        echo ""
-        echo ""
-        echo "  $green✓$reset  All reviewers complete"
+        printf "\n"
 
         # --- triage phase (runs in Evelyn's pane) ---
-        echo ""
-        echo "  $cyan● TRIAGE$reset  $dim────────────────────────────────────$reset"
-        echo ""
+        echo "  $cyan$bold round $round$reset$dim/$max_rounds$reset  $dim triaging$reset"
 
         set -l review_files
         for j in (seq $num_panes)
@@ -204,49 +189,29 @@ Your job:
 
         set frame_idx 1
         while not test -f $triage_sentinel
-            printf "\r  $dim$spinner_frames[$frame_idx]$reset  Triaging reviews..."
+            printf "\r  $dim$spinner_frames[$frame_idx]$reset  triaging..."
             set frame_idx (math "$frame_idx % 10 + 1")
-            sleep 0.08
+            sleep 0.05
         end
-        echo ""
-        echo ""
-        echo "  $green✓$reset  Triage complete"
+        printf "\n"
 
         # check triage result
         if grep -q "NO_ISSUES_FOUND" $round_dir/triage.md
             echo ""
-            echo ""
-            echo "$dim───────────────────────────────────────────────────$reset"
-            echo ""
-            echo "  $green●$reset  $bold PR #$pr_number is clean$reset"
-            echo ""
-            echo "  $dim No real issues found in round $round.$reset"
-            echo "  $dim Session: $session_dir$reset"
-            echo ""
-            echo "$dim───────────────────────────────────────────────────$reset"
+            echo "  $green$bold clean$reset $dim— no issues found$reset"
             echo ""
             return 0
         end
 
         if test "$dry_run" = true
             echo ""
-            echo ""
-            echo "$dim───────────────────────────────────────────────────$reset"
-            echo ""
-            echo "  $yellow●$reset  $bold Dry run complete$reset"
-            echo ""
-            echo "  $dim Issues found but skipping fix.$reset"
-            echo "  $dim Triage: $round_dir/triage.md$reset"
-            echo ""
-            echo "$dim───────────────────────────────────────────────────$reset"
+            echo "  $yellow$bold dry run$reset $dim— issues found, skipping fix$reset"
             echo ""
             return 0
         end
 
         # --- fix phase (runs in Evelyn's pane) ---
-        echo ""
-        echo "  $yellow● FIX$reset  $dim──────────────────────────────────────$reset"
-        echo ""
+        echo "  $yellow$bold round $round$reset$dim/$max_rounds$reset  $dim fixing$reset"
 
         set -l fix_sentinel "$round_dir/.done_fix"
         set -l fix_prompt "You are a senior engineer. Read the triaged code-review issues at $round_dir/triage.md using the Read tool. Fix every issue listed. Do not fix anything not listed. After fixing, commit your changes with a clear message referencing what was fixed. When completely done, run: touch $fix_sentinel"
@@ -256,28 +221,17 @@ Your job:
 
         set frame_idx 1
         while not test -f $fix_sentinel
-            printf "\r  $dim$spinner_frames[$frame_idx]$reset  Applying fixes..."
+            printf "\r  $dim$spinner_frames[$frame_idx]$reset  fixing..."
             set frame_idx (math "$frame_idx % 10 + 1")
-            sleep 0.08
+            sleep 0.05
         end
-        echo ""
-        echo ""
-        echo "  $green✓$reset  Fixes applied"
+        printf "\n"
 
         set round (math $round + 1)
     end
 
     echo ""
-    echo ""
-    echo "$dim───────────────────────────────────────────────────$reset"
-    echo ""
-    echo "  $red●$reset  $bold Max rounds reached$reset"
-    echo ""
-    echo "  $dim Completed $max_rounds rounds for PR #$pr_number.$reset"
-    echo "  $dim Review the last round's output manually.$reset"
-    echo "  $dim Session: $session_dir$reset"
-    echo ""
-    echo "$dim───────────────────────────────────────────────────$reset"
+    echo "  $red$bold max rounds$reset $dim— review manually$reset"
     echo ""
     return 1
 end

--- a/fish/.config/fish/functions/review_auto.fish
+++ b/fish/.config/fish/functions/review_auto.fish
@@ -341,9 +341,10 @@ function review_auto
         printf "\r                                                           \r"
         echo " "(set_color green)"✔"(set_color normal)" Triaged"
 
-        # check triage result - tolerate minor LLM formatting variance around the token
-        set -l _triage_content (cat $iter_dir/triage.md 2>/dev/null | string trim)
-        if string match -qr '^\s*NO_ISSUES_FOUND\s*$' -- "$_triage_content"
+        # check triage result - collapse into a single string so multi-line files
+        # are compared atomically instead of per-line via fish list semantics
+        set -l _triage_content (cat $iter_dir/triage.md 2>/dev/null | string collect | string trim)
+        if test "$_triage_content" = "NO_ISSUES_FOUND"
             wezterm cli kill-pane --pane-id $work_pane &>/dev/null
             echo " "(set_color green)"✔"(set_color normal)" No issues found"
             set -l total_dur (math (date +%s) - $session_start)

--- a/fish/.config/fish/functions/review_auto.fish
+++ b/fish/.config/fish/functions/review_auto.fish
@@ -155,6 +155,7 @@ function review_auto
             set -l prompt "$base_prompts[$j] IMPORTANT: When done, write your complete review to $outfile using the Write tool. Then run this shell command: touch $sentinel"
             set -l cmd "$review_cmd \"$prompt\""
             printf '%s\r' "$cmd" | wezterm cli send-text --no-paste --pane-id $pane_ids[$j]
+            sleep 0.5 # stagger to avoid cli-config.json race condition
         end
 
         # poll for all reviewers to finish with animated spinner

--- a/fish/.config/fish/functions/review_auto.fish
+++ b/fish/.config/fish/functions/review_auto.fish
@@ -168,7 +168,7 @@ function review_auto
             end
             
             set frame_idx (math "$frame_idx % 10 + 1")
-            sleep 0.5
+            sleep 0.08
         end
         echo ""
         echo ""
@@ -206,7 +206,7 @@ Your job:
         while not test -f $triage_sentinel
             printf "\r  $dim$spinner_frames[$frame_idx]$reset  Triaging reviews..."
             set frame_idx (math "$frame_idx % 10 + 1")
-            sleep 0.5
+            sleep 0.08
         end
         echo ""
         echo ""
@@ -258,7 +258,7 @@ Your job:
         while not test -f $fix_sentinel
             printf "\r  $dim$spinner_frames[$frame_idx]$reset  Applying fixes..."
             set frame_idx (math "$frame_idx % 10 + 1")
-            sleep 0.5
+            sleep 0.08
         end
         echo ""
         echo ""

--- a/fish/.config/fish/functions/review_auto.fish
+++ b/fish/.config/fish/functions/review_auto.fish
@@ -334,6 +334,13 @@ function review_auto
         printf "\r                                                           \r"
         echo " "(set_color green)"✔"(set_color normal)" Triaged"
 
+        # guard: triage.md must exist and be non-empty before proceeding
+        if not test -s $iter_dir/triage.md
+            echo " "(set_color red)"✗"(set_color normal)"  Triage produced empty or missing triage.md in iteration $iter"
+            rm -rf $session_dir
+            return 1
+        end
+
         # check triage result - collapse into a single string so multi-line files
         # are compared atomically instead of per-line via fish list semantics
         set -l _triage_content (cat $iter_dir/triage.md 2>/dev/null | string collect | string trim)
@@ -362,7 +369,7 @@ function review_auto
         end
 
         # --- fix phase ---
-        set work_pane (wezterm cli split-pane --pane-id $pane_0 --right)
+        set -l work_pane (wezterm cli split-pane --pane-id $pane_0 --right)
         if test -z "$work_pane"
             echo "Failed to create work pane for fix phase in iteration $iter"
             rm -rf $session_dir

--- a/fish/.config/fish/functions/review_auto.fish
+++ b/fish/.config/fish/functions/review_auto.fish
@@ -252,8 +252,8 @@ function review_auto
             set -l mins (math "floor($elapsed / 60)")
             set -l secs (math "$elapsed % 60")
             set -l time_str (printf "%d:%02d" $mins $secs)
-            set -l dots (printf "%-3s" $dot_frames[$frame_idx])
-            printf "\r %s·%s  Reviewing%s%s(%s/%s)%s  %s %s%s%s" (set_color $dot_colors[$frame_idx]) $reset "$dots" $dim $round $max_rounds $reset "$status_line" $dim $time_str $reset
+            set -l dots (printf "%-4s" $dot_frames[$frame_idx])
+            printf "\r %s•%s Reviewing%s%s(%s/%s)%s  %s %s%s%s" (set_color $dot_colors[$frame_idx]) $reset "$dots" $dim $round $max_rounds $reset "$status_line" $dim $time_str $reset
 
             if test $done_count -ge $num_panes
                 break
@@ -313,8 +313,8 @@ function review_auto
             set -l mins (math "floor($elapsed / 60)")
             set -l secs (math "$elapsed % 60")
             set -l time_str (printf "%d:%02d" $mins $secs)
-            set -l dots (printf "%-3s" $dot_frames[$frame_idx])
-            printf "\r %s·%s  Triaging%s %s%s%s" (set_color $dot_colors[$frame_idx]) $reset "$dots" $dim $time_str $reset
+            set -l dots (printf "%-4s" $dot_frames[$frame_idx])
+            printf "\r %s•%s Triaging%s %s%s%s" (set_color $dot_colors[$frame_idx]) $reset "$dots" $dim $time_str $reset
 
             set -l phase_elapsed (math (date +%s) - $triage_start)
             if test $phase_elapsed -ge $phase_timeout
@@ -380,8 +380,8 @@ function review_auto
             set -l mins (math "floor($elapsed / 60)")
             set -l secs (math "$elapsed % 60")
             set -l time_str (printf "%d:%02d" $mins $secs)
-            set -l dots (printf "%-3s" $dot_frames[$frame_idx])
-            printf "\r %s·%s  Fixing%s %s%s%s" (set_color $dot_colors[$frame_idx]) $reset "$dots" $dim $time_str $reset
+            set -l dots (printf "%-4s" $dot_frames[$frame_idx])
+            printf "\r %s•%s Fixing%s %s%s%s" (set_color $dot_colors[$frame_idx]) $reset "$dots" $dim $time_str $reset
 
             set -l phase_elapsed (math (date +%s) - $fix_start)
             if test $phase_elapsed -ge $phase_timeout

--- a/fish/.config/fish/functions/review_auto.fish
+++ b/fish/.config/fish/functions/review_auto.fish
@@ -154,6 +154,7 @@ function review_auto
     end
 
     # --- header (printed once) ---
+    set -l session_start (date +%s)
     printf "\n\n"
     set -l pr_label "PR #$pr_number"
     if test -n "$pr_title"
@@ -248,18 +249,18 @@ function review_auto
                 end
             end
 
-            set -l phase_el (math (date +%s) - $round_start)
-            set -l phase_m (math "floor($phase_el / 60)")
-            set -l phase_s (math "$phase_el % 60")
-            set -l phase_ts (printf "%d:%02d" $phase_m $phase_s)
+            set -l total_el (math (date +%s) - $round_start)
+            set -l total_m (math "floor($total_el / 60)")
+            set -l total_s (math "$total_el % 60")
+            set -l total_ts (printf "%d:%02d" $total_m $total_s)
             set -l dots (printf "%-4s" $dot_frames[$frame_idx])
-            printf "\r %s•%s Reviewing%s%s(%s/%s)%s  %s %s%s%s" (set_color $dot_colors[$frame_idx]) $reset "$dots" $dim $round $max_rounds $reset "$status_line" $dim $phase_ts $reset
+            printf "\r %s•%s Reviewing%s%s(%s/%s)%s  %s %s%s%s" (set_color $dot_colors[$frame_idx]) $reset "$dots" $dim $round $max_rounds $reset "$status_line" $dim $total_ts $reset
 
             if test $done_count -ge $num_panes
                 break
             end
 
-            if test $phase_el -ge $phase_timeout
+            if test $total_el -ge $phase_timeout
                 printf "\r                                                           \r"
                 echo " "(set_color red)"✗"(set_color normal)"  Review phase timed out after $phase_timeout seconds in round $round"
                 for pane in $pane_ids
@@ -271,11 +272,6 @@ function review_auto
             set frame_idx (math "$frame_idx % 3 + 1")
             sleep 0.15
         end
-        set -l review_dur (math (date +%s) - $round_start)
-        set -l review_dur_m (math "floor($review_dur / 60)")
-        set -l review_dur_s (math "$review_dur % 60")
-        set -l review_dur_str (printf "%d:%02d" $review_dur_m $review_dur_s)
-
         # kill reviewer panes and create fresh work pane before printing final status
         # (pane resize happens here, before any output)
         for pane in $pane_ids
@@ -288,7 +284,7 @@ function review_auto
         end
 
         printf "\r                                                           \r"
-        echo " "(set_color green)"✔"(set_color normal)" Reviewed "(set_color brblack)"($round/$max_rounds)"(set_color normal)"  $status_line"(set_color brblack)"$review_dur_str"(set_color normal)
+        echo " "(set_color green)"✔"(set_color normal)" Reviewed "(set_color brblack)"($round/$max_rounds)"(set_color normal)
 
         # --- triage phase ---
         set -l review_files
@@ -309,18 +305,14 @@ function review_auto
         set -l triage_start (date +%s)
         set frame_idx 1
         while not test -f $triage_sentinel
-            set -l phase_el (math (date +%s) - $triage_start)
-            set -l phase_m (math "floor($phase_el / 60)")
-            set -l phase_s (math "$phase_el % 60")
-            set -l phase_ts (printf "%d:%02d" $phase_m $phase_s)
             set -l total_el (math (date +%s) - $round_start)
             set -l total_m (math "floor($total_el / 60)")
             set -l total_s (math "$total_el % 60")
             set -l total_ts (printf "%d:%02d" $total_m $total_s)
             set -l dots (printf "%-4s" $dot_frames[$frame_idx])
-            printf "\r %s•%s Triaging%s %s%s%s  %s%s%s" (set_color $dot_colors[$frame_idx]) $reset "$dots" $dim $phase_ts $reset $dim $total_ts $reset
+            printf "\r %s•%s Triaging%s %s%s%s" (set_color $dot_colors[$frame_idx]) $reset "$dots" $dim $total_ts $reset
 
-            set -l phase_elapsed $phase_el
+            set -l phase_elapsed (math (date +%s) - $triage_start)
             if test $phase_elapsed -ge $phase_timeout
                 printf "\r                                                           \r"
                 echo " "(set_color red)"✗"(set_color normal)"  Triage phase timed out after $phase_timeout seconds in round $round"
@@ -331,11 +323,6 @@ function review_auto
             set frame_idx (math "$frame_idx % 3 + 1")
             sleep 0.15
         end
-        set -l triage_dur (math (date +%s) - $triage_start)
-        set -l triage_dur_m (math "floor($triage_dur / 60)")
-        set -l triage_dur_s (math "$triage_dur % 60")
-        set -l triage_dur_str (printf "%d:%02d" $triage_dur_m $triage_dur_s)
-
         # kill triage pane and create fresh one before printing
         # (pane resize happens here, before any output)
         wezterm cli kill-pane --pane-id $work_pane &>/dev/null
@@ -346,15 +333,18 @@ function review_auto
         end
 
         printf "\r                                                           \r"
-        echo " "(set_color green)"✔"(set_color normal)" Triaged  "(set_color brblack)"$triage_dur_str"(set_color normal)
+        echo " "(set_color green)"✔"(set_color normal)" Triaged"
 
         # check triage result - compare trimmed entire file to exact string
         set -l _triage_content (string trim (cat $round_dir/triage.md 2>/dev/null))
         if test "$_triage_content" = NO_ISSUES_FOUND
             wezterm cli kill-pane --pane-id $work_pane &>/dev/null
             echo " "(set_color green)"●"(set_color normal)"  "(set_color --bold)"clean"(set_color normal)" "(set_color brblack)"— no issues found"(set_color normal)
+            set -l total_dur (math (date +%s) - $session_start)
+            set -l total_dur_m (math "floor($total_dur / 60)")
+            set -l total_dur_s (math "$total_dur % 60")
             echo ""
-            echo " "(set_color brblack)$pr_url(set_color normal)
+            echo " "(set_color brblack)$pr_url" · "(printf "%dm %ds" $total_dur_m $total_dur_s)(set_color normal)
             echo ""
             return 0
         end
@@ -362,8 +352,11 @@ function review_auto
         if test "$dry_run" = true
             wezterm cli kill-pane --pane-id $work_pane &>/dev/null
             echo " "(set_color yellow)"●"(set_color normal)"  "(set_color --bold)"dry run"(set_color normal)" "(set_color brblack)"— issues found, skipping fix"(set_color normal)
+            set -l total_dur (math (date +%s) - $session_start)
+            set -l total_dur_m (math "floor($total_dur / 60)")
+            set -l total_dur_s (math "$total_dur % 60")
             echo ""
-            echo " "(set_color brblack)$pr_url(set_color normal)
+            echo " "(set_color brblack)$pr_url" · "(printf "%dm %ds" $total_dur_m $total_dur_s)(set_color normal)
             echo ""
             return 0
         end
@@ -381,18 +374,14 @@ function review_auto
         set -l fix_start (date +%s)
         set frame_idx 1
         while not test -f $fix_sentinel
-            set -l phase_el (math (date +%s) - $fix_start)
-            set -l phase_m (math "floor($phase_el / 60)")
-            set -l phase_s (math "$phase_el % 60")
-            set -l phase_ts (printf "%d:%02d" $phase_m $phase_s)
             set -l total_el (math (date +%s) - $round_start)
             set -l total_m (math "floor($total_el / 60)")
             set -l total_s (math "$total_el % 60")
             set -l total_ts (printf "%d:%02d" $total_m $total_s)
             set -l dots (printf "%-4s" $dot_frames[$frame_idx])
-            printf "\r %s•%s Fixing%s %s%s%s  %s%s%s" (set_color $dot_colors[$frame_idx]) $reset "$dots" $dim $phase_ts $reset $dim $total_ts $reset
+            printf "\r %s•%s Fixing%s %s%s%s" (set_color $dot_colors[$frame_idx]) $reset "$dots" $dim $total_ts $reset
 
-            set -l phase_elapsed $phase_el
+            set -l phase_elapsed (math (date +%s) - $fix_start)
             if test $phase_elapsed -ge $phase_timeout
                 printf "\r                                                           \r"
                 echo " "(set_color red)"✗"(set_color normal)"  Fix phase timed out after $phase_timeout seconds in round $round"
@@ -403,12 +392,8 @@ function review_auto
             set frame_idx (math "$frame_idx % 3 + 1")
             sleep 0.15
         end
-        set -l fix_dur (math (date +%s) - $fix_start)
-        set -l fix_dur_m (math "floor($fix_dur / 60)")
-        set -l fix_dur_s (math "$fix_dur % 60")
-        set -l fix_dur_str (printf "%d:%02d" $fix_dur_m $fix_dur_s)
         printf "\r                                                           \r"
-        echo " "(set_color green)"✔"(set_color normal)" Fixed  "(set_color brblack)"$fix_dur_str"(set_color normal)
+        echo " "(set_color green)"✔"(set_color normal)" Fixed"
 
         # kill work pane before next round
         wezterm cli kill-pane --pane-id $work_pane &>/dev/null
@@ -418,8 +403,11 @@ function review_auto
 
     echo ""
     echo " "(set_color red)"●"(set_color normal)"  "(set_color --bold)"max rounds"(set_color normal)" "(set_color brblack)"— review manually"(set_color normal)
+    set -l total_dur (math (date +%s) - $session_start)
+    set -l total_dur_m (math "floor($total_dur / 60)")
+    set -l total_dur_s (math "$total_dur % 60")
     echo ""
-    echo " "(set_color brblack)$pr_url(set_color normal)
+    echo " "(set_color brblack)$pr_url" · "(printf "%dm %ds" $total_dur_m $total_dur_s)(set_color normal)
     echo ""
     return 1
 end

--- a/fish/.config/fish/functions/review_auto.fish
+++ b/fish/.config/fish/functions/review_auto.fish
@@ -373,12 +373,12 @@ function review_auto
             set -l mins (math "floor($elapsed / 60)")
             set -l secs (math "$elapsed % 60")
             set -l time_str (printf "%d:%02d" $mins $secs)
-            printf "\r %s%s%s  Fix  %s%s%s" $dim $spinner_frames[$frame_idx] $reset $dim $time_str $reset
+            printf "\r %s%s%s  Address  %s%s%s" $dim $spinner_frames[$frame_idx] $reset $dim $time_str $reset
 
             set -l phase_elapsed (math (date +%s) - $fix_start)
             if test $phase_elapsed -ge $phase_timeout
                 printf "\r                                                           \r"
-                echo " "(set_color red)"✗"(set_color normal)"  Fix phase timed out after $phase_timeout seconds in round $round"
+                echo " "(set_color red)"✗"(set_color normal)"  Address phase timed out after $phase_timeout seconds in round $round"
                 wezterm cli kill-pane --pane-id $work_pane &>/dev/null
                 return 1
             end
@@ -391,7 +391,7 @@ function review_auto
         set -l secs (math "$elapsed % 60")
         set -l time_str (printf "%d:%02d" $mins $secs)
         printf "\r                                                           \r"
-        echo " "(set_color green)"✔"(set_color normal)"  Fix  "(set_color brblack)"$time_str"(set_color normal)
+        echo " "(set_color green)"✔"(set_color normal)"  Address  "(set_color brblack)"$time_str"(set_color normal)
 
         # kill work pane before next round
         wezterm cli kill-pane --pane-id $work_pane &>/dev/null

--- a/fish/.config/fish/functions/review_auto.fish
+++ b/fish/.config/fish/functions/review_auto.fish
@@ -82,10 +82,6 @@ function review_auto
     set -l reset (set_color normal)
     set -l green (set_color green)
 
-    printf "\n"
-    set -l header1 "   "(set_color --bold)"review_auto"(set_color normal)"  "(set_color brblack)"·"(set_color normal)"  PR #"(set_color cyan)$pr_number(set_color normal)
-    echo $header1
-
     # --- split panes: 4 quadrants (orchestrator + 3 reviewers) ---
     # Layout:
     # ┌─────────────────────┬─────────────────────┐
@@ -125,6 +121,8 @@ function review_auto
         set -l round_dir $session_dir/round_$round
         mkdir -p $round_dir
 
+        printf "\n"
+        echo "   "(set_color --bold)"review_auto"(set_color normal)"  "(set_color brblack)"·"(set_color normal)"  PR #"(set_color cyan)$pr_number(set_color normal)
         echo "   "(set_color brblack)"$provider · $num_panes reviewers · round $round/$max_rounds"(set_color normal)
         echo ""
         set -l round_start (date +%s)

--- a/fish/.config/fish/functions/review_auto.fish
+++ b/fish/.config/fish/functions/review_auto.fish
@@ -253,7 +253,7 @@ function review_auto
             set -l secs (math "$elapsed % 60")
             set -l time_str (printf "%d:%02d" $mins $secs)
             set -l dots (printf "%-4s" $dot_frames[$frame_idx])
-            printf "\r  %s•%s Reviewing%s%s(%s/%s)%s  %s %s%s%s" (set_color $dot_colors[$frame_idx]) $reset "$dots" $dim $round $max_rounds $reset "$status_line" $dim $time_str $reset
+            printf "\r %s•%s Reviewing%s%s(%s/%s)%s  %s %s%s%s" (set_color $dot_colors[$frame_idx]) $reset "$dots" $dim $round $max_rounds $reset "$status_line" $dim $time_str $reset
 
             if test $done_count -ge $num_panes
                 break
@@ -288,7 +288,7 @@ function review_auto
         end
 
         printf "\r                                                           \r"
-        echo "  "(set_color green)"✔"(set_color normal)" Reviewed "(set_color brblack)"($round/$max_rounds)"(set_color normal)"  $status_line"(set_color brblack)"$time_str"(set_color normal)
+        echo " "(set_color green)"✔"(set_color normal)" Reviewed "(set_color brblack)"($round/$max_rounds)"(set_color normal)"  $status_line"(set_color brblack)"$time_str"(set_color normal)
 
         # --- triage phase ---
         set -l review_files
@@ -314,7 +314,7 @@ function review_auto
             set -l secs (math "$elapsed % 60")
             set -l time_str (printf "%d:%02d" $mins $secs)
             set -l dots (printf "%-4s" $dot_frames[$frame_idx])
-            printf "\r  %s•%s Triaging%s %s%s%s" (set_color $dot_colors[$frame_idx]) $reset "$dots" $dim $time_str $reset
+            printf "\r %s•%s Triaging%s %s%s%s" (set_color $dot_colors[$frame_idx]) $reset "$dots" $dim $time_str $reset
 
             set -l phase_elapsed (math (date +%s) - $triage_start)
             if test $phase_elapsed -ge $phase_timeout
@@ -342,7 +342,7 @@ function review_auto
         end
 
         printf "\r                                                           \r"
-        echo "  "(set_color green)"✔"(set_color normal)" Triaged  "(set_color brblack)"$time_str"(set_color normal)
+        echo " "(set_color green)"✔"(set_color normal)" Triaged  "(set_color brblack)"$time_str"(set_color normal)
 
         # check triage result - trim whitespace and match robustly
         if string match -qr '^\s*NO_ISSUES_FOUND\s*$' < $round_dir/triage.md 2>/dev/null
@@ -381,7 +381,7 @@ function review_auto
             set -l secs (math "$elapsed % 60")
             set -l time_str (printf "%d:%02d" $mins $secs)
             set -l dots (printf "%-4s" $dot_frames[$frame_idx])
-            printf "\r  %s•%s Fixing%s %s%s%s" (set_color $dot_colors[$frame_idx]) $reset "$dots" $dim $time_str $reset
+            printf "\r %s•%s Fixing%s %s%s%s" (set_color $dot_colors[$frame_idx]) $reset "$dots" $dim $time_str $reset
 
             set -l phase_elapsed (math (date +%s) - $fix_start)
             if test $phase_elapsed -ge $phase_timeout
@@ -399,7 +399,7 @@ function review_auto
         set -l secs (math "$elapsed % 60")
         set -l time_str (printf "%d:%02d" $mins $secs)
         printf "\r                                                           \r"
-        echo "  "(set_color green)"✔"(set_color normal)" Fixed  "(set_color brblack)"$time_str"(set_color normal)
+        echo " "(set_color green)"✔"(set_color normal)" Fixed  "(set_color brblack)"$time_str"(set_color normal)
 
         # kill work pane before next round
         wezterm cli kill-pane --pane-id $work_pane &>/dev/null

--- a/fish/.config/fish/functions/review_auto.fish
+++ b/fish/.config/fish/functions/review_auto.fish
@@ -84,10 +84,7 @@ function review_auto
 
     printf "\n"
     set -l header1 "   "(set_color --bold)"review_auto"(set_color normal)"  "(set_color brblack)"·"(set_color normal)"  PR #"(set_color cyan)$pr_number(set_color normal)
-    set -l header2 "   "(set_color brblack)$provider" · "$num_panes" reviewers · "$max_rounds" rounds max"(set_color normal)
     echo $header1
-    echo $header2
-    echo ""
 
     # --- split panes: 4 quadrants (orchestrator + 3 reviewers) ---
     # Layout:
@@ -128,10 +125,8 @@ function review_auto
         set -l round_dir $session_dir/round_$round
         mkdir -p $round_dir
 
+        echo "   "(set_color brblack)"$provider · $num_panes reviewers · round $round/$max_rounds"(set_color normal)
         echo ""
-        echo "   "(set_color brblack)"round $round / $max_rounds"(set_color normal)
-        echo ""
-
         set -l round_start (date +%s)
 
         # On round 2+, recreate reviewer panes (they were killed after the previous review phase)

--- a/fish/.config/fish/functions/review_auto.fish
+++ b/fish/.config/fish/functions/review_auto.fish
@@ -1,8 +1,8 @@
 function review_auto
-    # Usage: review_auto [--max-rounds N] [--provider openai|anthropic] [--panes 1-3] [--timeout SECS] [--dry-run]
+    # Usage: review_auto [--max-iterations N] [--provider openai|anthropic] [--panes 1-3] [--timeout SECS] [--dry-run]
     # Uses --yolo so agents can run shell tools (gh cli, git, etc.) for PR inspection.
     # Default: 3 reviewers (Evelyn, Vivian, Stella) in 4-quadrant layout.
-    set -l max_rounds 3
+    set -l max_iters 3
     set -l provider anthropic
     set -l num_panes 3
     set -l phase_timeout 600
@@ -12,17 +12,17 @@ function review_auto
     set -l argc (count $argv)
     while test $i -le $argc
         switch $argv[$i]
-            case --max-rounds
+            case --max-iterations
                 set i (math $i + 1)
                 if test $i -gt $argc
-                    echo "Missing value for --max-rounds"
+                    echo "Missing value for --max-iterations"
                     return 1
                 end
                 if not string match -qr '^\d+$' -- $argv[$i]; or test $argv[$i] -le 0
-                    echo "Invalid --max-rounds value: '$argv[$i]' (must be a positive integer)"
+                    echo "Invalid --max-iterations value: '$argv[$i]' (must be a positive integer)"
                     return 1
                 end
-                set max_rounds $argv[$i]
+                set max_iters $argv[$i]
             case --provider
                 set i (math $i + 1)
                 if test $i -gt $argc
@@ -56,7 +56,7 @@ function review_auto
                 set dry_run true
             case '*'
                 echo "Unknown argument: $argv[$i]"
-                echo "Usage: review_auto [--max-rounds N] [--provider openai|anthropic] [--panes 1-3] [--timeout SECS] [--dry-run]"
+                echo "Usage: review_auto [--max-iterations N] [--provider openai|anthropic] [--panes 1-3] [--timeout SECS] [--dry-run]"
                 return 1
         end
         set i (math $i + 1)
@@ -173,31 +173,31 @@ function review_auto
     echo ""
 
     # --- main loop ---
-    set -l round 1
-    while test $round -le $max_rounds
-        set -l round_dir $session_dir/round_$round
-        mkdir -p $round_dir
+    set -l iter 1
+    while test $iter -le $max_iters
+        set -l iter_dir $session_dir/iter_$iter
+        mkdir -p $iter_dir
 
-        set -l round_start (date +%s)
+        set -l iter_start (date +%s)
 
-        # On round 2+, recreate reviewer panes (same quadrant layout as initial)
-        if test $round -gt 1
+        # On iteration 2+, recreate reviewer panes (same quadrant layout as initial)
+        if test $iter -gt 1
             set -l pb (wezterm cli split-pane --pane-id $pane_0 --bottom)
             if test -z "$pb"
-                echo "Failed to recreate bottom pane in round $round"
+                echo "Failed to recreate bottom pane in iteration $iter"
                 rm -rf $session_dir
                 return 1
             end
             set -l pe (wezterm cli split-pane --pane-id $pane_0 --right)
             if test -z "$pe"
-                echo "Failed to recreate Evelyn pane in round $round"
+                echo "Failed to recreate Evelyn pane in iteration $iter"
                 wezterm cli kill-pane --pane-id $pb &>/dev/null
                 rm -rf $session_dir
                 return 1
             end
             set -l ps (wezterm cli split-pane --pane-id $pb --right)
             if test -z "$ps"
-                echo "Failed to recreate Stella pane in round $round"
+                echo "Failed to recreate Stella pane in iteration $iter"
                 wezterm cli kill-pane --pane-id $pe &>/dev/null
                 wezterm cli kill-pane --pane-id $pb &>/dev/null
                 rm -rf $session_dir
@@ -217,16 +217,16 @@ function review_auto
         # clean sentinel files
         for j in (seq $num_panes)
             set -l name (string lower $names[$j])
-            rm -f $round_dir/.done_$name
+            rm -f $iter_dir/.done_$name
         end
 
         # dispatch review agents to panes (prompts written to temp files to avoid shell metacharacter issues)
         for j in (seq $num_panes)
             set -l name (string lower $names[$j])
-            set -l outfile "$round_dir/review_$name.md"
-            set -l sentinel "$round_dir/.done_$name"
+            set -l outfile "$iter_dir/review_$name.md"
+            set -l sentinel "$iter_dir/.done_$name"
             set -l prompt "$base_prompts[$j] IMPORTANT: When done, write your complete review to $outfile using the Write tool. Then run this shell command: touch $sentinel"
-            set -l prompt_file "$round_dir/prompt_review_$name.txt"
+            set -l prompt_file "$iter_dir/prompt_review_$name.txt"
             printf '%s' "$prompt" > $prompt_file
             set -l cmd "$review_cmd \"\$(cat $prompt_file)\""
             printf '%s\r' "$cmd" | wezterm cli send-text --no-paste --pane-id $pane_ids[$j]
@@ -243,7 +243,7 @@ function review_auto
             for j in (seq $num_panes)
                 set -l name $names[$j]
                 set -l name_lower (string lower $name)
-                if test -f $round_dir/.done_$name_lower
+                if test -f $iter_dir/.done_$name_lower
                     set done_count (math $done_count + 1)
                     set status_line "$status_line$green$name$reset  "
                 else
@@ -251,12 +251,12 @@ function review_auto
                 end
             end
 
-            set -l total_el (math (date +%s) - $round_start)
+            set -l total_el (math (date +%s) - $iter_start)
             set -l total_m (math "floor($total_el / 60)")
             set -l total_s (math "$total_el % 60")
             set -l total_ts (printf "%d:%02d" $total_m $total_s)
             set -l dots (printf "%-4s" $dot_frames[$frame_idx])
-            printf "\r %s•%s Reviewing%s%s(%s/%s)%s  %s %s%s%s" (set_color $dot_colors[$frame_idx]) $reset "$dots" $dim $round $max_rounds $reset "$status_line" $dim $total_ts $reset
+            printf "\r %s•%s Reviewing%s%s(%s/%s)%s  %s %s%s%s" (set_color $dot_colors[$frame_idx]) $reset "$dots" $dim $iter $max_iters $reset "$status_line" $dim $total_ts $reset
 
             if test $done_count -ge $num_panes
                 break
@@ -264,7 +264,7 @@ function review_auto
 
             if test $total_el -ge $phase_timeout
                 printf "\r                                                           \r"
-                echo " "(set_color red)"✗"(set_color normal)"  Review phase timed out after $phase_timeout seconds in round $round"
+                echo " "(set_color red)"✗"(set_color normal)"  Review phase timed out after $phase_timeout seconds in iteration $iter"
                 for pane in $pane_ids
                     wezterm cli kill-pane --pane-id $pane &>/dev/null
                 end
@@ -282,26 +282,26 @@ function review_auto
         end
         set -l work_pane (wezterm cli split-pane --pane-id $pane_0 --right)
         if test -z "$work_pane"
-            echo "Failed to create work pane after review phase in round $round"
+            echo "Failed to create work pane after review phase in iteration $iter"
             rm -rf $session_dir
             return 1
         end
 
         printf "\r                                                           \r"
-        echo " "(set_color green)"✔"(set_color normal)" Reviewed "(set_color brblack)"($round/$max_rounds)"(set_color normal)
+        echo " "(set_color green)"✔"(set_color normal)" Reviewed"
 
         # --- triage phase ---
         set -l review_files
         for j in (seq $num_panes)
             set -l name (string lower $names[$j])
-            set -a review_files "$round_dir/review_$name.md"
+            set -a review_files "$iter_dir/review_$name.md"
         end
         set -l file_list (string join ", " $review_files)
 
-        set -l triage_sentinel "$round_dir/.done_triage"
-        set -l triage_prompt "You are a code-review triage agent. Read the review output files at: $file_list. Read all review files using the Read tool. Filter out nitpicks, style-only comments, and false positives. Identify ONLY real bugs, logic errors, security vulnerabilities, or missing error handling. If a review file is empty or contains an error, skip it. Write your verdict to $round_dir/triage.md. If there are NO real issues: write ONLY the text NO_ISSUES_FOUND (nothing else, just that one line). If there ARE real issues: write each issue with file path, line number, severity (critical/high/medium), and description. Do NOT include the string NO_ISSUES_FOUND anywhere. When completely done, run this shell command: touch $triage_sentinel"
+        set -l triage_sentinel "$iter_dir/.done_triage"
+        set -l triage_prompt "You are a code-review triage agent. Read the review output files at: $file_list. Read all review files using the Read tool. Filter out nitpicks, style-only comments, and false positives. Identify ONLY real bugs, logic errors, security vulnerabilities, or missing error handling. If a review file is empty or contains an error, skip it. Write your verdict to $iter_dir/triage.md. If there are NO real issues: write ONLY the text NO_ISSUES_FOUND (nothing else, just that one line). If there ARE real issues: write each issue with file path, line number, severity (critical/high/medium), and description. Do NOT include the string NO_ISSUES_FOUND anywhere. When completely done, run this shell command: touch $triage_sentinel"
 
-        set -l triage_prompt_file "$round_dir/prompt_triage.txt"
+        set -l triage_prompt_file "$iter_dir/prompt_triage.txt"
         printf '%s' "$triage_prompt" > $triage_prompt_file
         set -l triage_cmd "cursor-agent --yolo --model $triage_model \"\$(cat $triage_prompt_file)\""
         printf '%s\r' "$triage_cmd" | wezterm cli send-text --no-paste --pane-id $work_pane
@@ -309,7 +309,7 @@ function review_auto
         set -l triage_start (date +%s)
         set frame_idx 1
         while not test -f $triage_sentinel
-            set -l total_el (math (date +%s) - $round_start)
+            set -l total_el (math (date +%s) - $iter_start)
             set -l total_m (math "floor($total_el / 60)")
             set -l total_s (math "$total_el % 60")
             set -l total_ts (printf "%d:%02d" $total_m $total_s)
@@ -319,7 +319,7 @@ function review_auto
             set -l phase_elapsed (math (date +%s) - $triage_start)
             if test $phase_elapsed -ge $phase_timeout
                 printf "\r                                                           \r"
-                echo " "(set_color red)"✗"(set_color normal)"  Triage phase timed out after $phase_timeout seconds in round $round"
+                echo " "(set_color red)"✗"(set_color normal)"  Triage phase timed out after $phase_timeout seconds in iteration $iter"
                 wezterm cli kill-pane --pane-id $work_pane &>/dev/null
                 rm -rf $session_dir
                 return 1
@@ -333,7 +333,7 @@ function review_auto
         wezterm cli kill-pane --pane-id $work_pane &>/dev/null
         set work_pane (wezterm cli split-pane --pane-id $pane_0 --right)
         if test -z "$work_pane"
-            echo "Failed to create work pane after triage phase in round $round"
+            echo "Failed to create work pane after triage phase in iteration $iter"
             rm -rf $session_dir
             return 1
         end
@@ -342,7 +342,7 @@ function review_auto
         echo " "(set_color green)"✔"(set_color normal)" Triaged"
 
         # check triage result - tolerate minor LLM formatting variance around the token
-        set -l _triage_content (cat $round_dir/triage.md 2>/dev/null | string trim)
+        set -l _triage_content (cat $iter_dir/triage.md 2>/dev/null | string trim)
         if string match -qr '^\s*NO_ISSUES_FOUND\s*$' -- "$_triage_content"
             wezterm cli kill-pane --pane-id $work_pane &>/dev/null
             echo " "(set_color green)"✔"(set_color normal)" No issues found"
@@ -369,10 +369,10 @@ function review_auto
 
         # --- fix phase (work pane already created above) ---
 
-        set -l fix_sentinel "$round_dir/.done_fix"
-        set -l fix_prompt "Read the triaged code-review issues at $round_dir/triage.md using the Read tool. Fix every issue listed. Do not fix anything not listed. After fixing, commit your changes with a clear message referencing what was fixed, then push to the remote branch with git push. Then use the /pr skill to update the PR title and description. When completely done, run this shell command: touch $fix_sentinel"
+        set -l fix_sentinel "$iter_dir/.done_fix"
+        set -l fix_prompt "Read the triaged code-review issues at $iter_dir/triage.md using the Read tool. Fix every issue listed. Do not fix anything not listed. After fixing, commit your changes with a clear message referencing what was fixed, then push to the remote branch with git push. Then use the /pr skill to update the PR title and description. When completely done, run this shell command: touch $fix_sentinel"
 
-        set -l fix_prompt_file "$round_dir/prompt_fix.txt"
+        set -l fix_prompt_file "$iter_dir/prompt_fix.txt"
         printf '%s' "$fix_prompt" > $fix_prompt_file
         set -l fix_cmd "cursor-agent --yolo --model $fix_model \"\$(cat $fix_prompt_file)\""
         printf '%s\r' "$fix_cmd" | wezterm cli send-text --no-paste --pane-id $work_pane
@@ -380,7 +380,7 @@ function review_auto
         set -l fix_start (date +%s)
         set frame_idx 1
         while not test -f $fix_sentinel
-            set -l total_el (math (date +%s) - $round_start)
+            set -l total_el (math (date +%s) - $iter_start)
             set -l total_m (math "floor($total_el / 60)")
             set -l total_s (math "$total_el % 60")
             set -l total_ts (printf "%d:%02d" $total_m $total_s)
@@ -390,7 +390,7 @@ function review_auto
             set -l phase_elapsed (math (date +%s) - $fix_start)
             if test $phase_elapsed -ge $phase_timeout
                 printf "\r                                                           \r"
-                echo " "(set_color red)"✗"(set_color normal)"  Fix phase timed out after $phase_timeout seconds in round $round"
+                echo " "(set_color red)"✗"(set_color normal)"  Fix phase timed out after $phase_timeout seconds in iteration $iter"
                 wezterm cli kill-pane --pane-id $work_pane &>/dev/null
                 rm -rf $session_dir
                 return 1
@@ -402,14 +402,14 @@ function review_auto
         printf "\r                                                           \r"
         echo " "(set_color green)"✔"(set_color normal)" Fixed"
 
-        # kill work pane before next round
+        # kill work pane before next iteration
         wezterm cli kill-pane --pane-id $work_pane &>/dev/null
 
-        set round (math $round + 1)
+        set iter (math $iter + 1)
     end
 
     echo ""
-    echo " "(set_color red)"✗"(set_color normal)" Max rounds reached"
+    echo " "(set_color red)"✗"(set_color normal)" Max iterations reached"
     set -l total_dur (math (date +%s) - $session_start)
     set -l total_dur_m (math "floor($total_dur / 60)")
     set -l total_dur_s (math "$total_dur % 60")

--- a/fish/.config/fish/functions/review_auto.fish
+++ b/fish/.config/fish/functions/review_auto.fish
@@ -107,11 +107,11 @@ function review_auto
 
     # Kill unused panes if num_panes < 3
     if test $num_panes -lt 3
-        wezterm cli kill-pane --pane-id $pane_stella 2>/dev/null
+        wezterm cli kill-pane --pane-id $pane_stella &>/dev/null
         set pane_ids $pane_evelyn $pane_vivian
     end
     if test $num_panes -lt 2
-        wezterm cli kill-pane --pane-id $pane_vivian 2>/dev/null
+        wezterm cli kill-pane --pane-id $pane_vivian &>/dev/null
         set pane_ids $pane_evelyn
     end
 
@@ -124,6 +124,7 @@ function review_auto
         printf "\n\n"
         echo " "(set_color --bold)"review_auto"(set_color normal)"  "(set_color brblack)"·"(set_color normal)"  PR #"(set_color cyan)$pr_number(set_color normal)
         echo " "(set_color brblack)"$provider · $num_panes reviewers · round $round/$max_rounds"(set_color normal)
+        echo ""
         set -l round_start (date +%s)
 
         # On round 2+, recreate reviewer panes (they were killed after the previous review phase)
@@ -195,7 +196,7 @@ function review_auto
 
         # kill reviewer panes and create fresh pane for triage/fix
         for pane in $pane_ids
-            wezterm cli kill-pane --pane-id $pane 2>/dev/null
+            wezterm cli kill-pane --pane-id $pane &>/dev/null
         end
         set -l work_pane (wezterm cli split-pane --pane-id $pane_0 --right)
 
@@ -245,7 +246,7 @@ function review_auto
 
         # --- fix phase ---
         # kill triage pane and create fresh one for fix
-        wezterm cli kill-pane --pane-id $work_pane 2>/dev/null
+        wezterm cli kill-pane --pane-id $work_pane &>/dev/null
         set work_pane (wezterm cli split-pane --pane-id $pane_0 --right)
 
         set -l fix_sentinel "$round_dir/.done_fix"
@@ -272,7 +273,7 @@ function review_auto
         echo " "(set_color white)"●"(set_color normal)"  fix  "(set_color brblack)"$time_str"(set_color normal)
 
         # kill work pane before next round
-        wezterm cli kill-pane --pane-id $work_pane 2>/dev/null
+        wezterm cli kill-pane --pane-id $work_pane &>/dev/null
 
         set round (math $round + 1)
     end

--- a/fish/.config/fish/functions/review_auto.fish
+++ b/fish/.config/fish/functions/review_auto.fish
@@ -1,5 +1,6 @@
 function review_auto
     # Usage: review_auto [--max-rounds N] [--provider openai|anthropic] [--panes 1-4] [--dry-run]
+    # Uses --yolo so agents can run shell tools (gh cli, git, etc.) for PR inspection.
     set -l max_rounds 3
     set -l provider anthropic
     set -l num_panes 4

--- a/fish/.config/fish/functions/review_auto.fish
+++ b/fish/.config/fish/functions/review_auto.fish
@@ -230,8 +230,9 @@ function review_auto
             sleep 0.5 # stagger to avoid cli-config.json race condition
         end
 
-        # poll for all reviewers to finish with animated spinner
-        set -l spinner_frames "⠋" "⠙" "⠹" "⠸" "⠼" "⠴" "⠦" "⠧" "⠇" "⠏"
+        # poll for all reviewers to finish
+        set -l dot_frames "." ".." "..." "..."
+        set -l dot_colors green green green white
         set -l frame_idx 1
         while true
             set -l done_count 0
@@ -251,7 +252,8 @@ function review_auto
             set -l mins (math "floor($elapsed / 60)")
             set -l secs (math "$elapsed % 60")
             set -l time_str (printf "%d:%02d" $mins $secs)
-            printf "\r %s%s%s  Review %s(%s/%s)%s  %s %s%s%s" $dim $spinner_frames[$frame_idx] $reset $dim $round $max_rounds $reset "$status_line" $dim $time_str $reset
+            set -l dots (printf "%-3s" $dot_frames[$frame_idx])
+            printf "\r %s·%s  Reviewing%s%s(%s/%s)%s  %s %s%s%s" (set_color $dot_colors[$frame_idx]) $reset "$dots" $dim $round $max_rounds $reset "$status_line" $dim $time_str $reset
 
             if test $done_count -ge $num_panes
                 break
@@ -266,8 +268,8 @@ function review_auto
                 return 1
             end
 
-            set frame_idx (math "$frame_idx % 10 + 1")
-            sleep 0.05 # ~20 FPS for smooth spinner animation
+            set frame_idx (math "$frame_idx % 4 + 1")
+            sleep 0.3
         end
         set -l elapsed (math (date +%s) - $round_start)
         set -l mins (math "floor($elapsed / 60)")
@@ -286,7 +288,7 @@ function review_auto
         end
 
         printf "\r                                                           \r"
-        echo " "(set_color green)"✔"(set_color normal)"  Review "(set_color brblack)"($round/$max_rounds)"(set_color normal)"  $status_line"(set_color brblack)"$time_str"(set_color normal)
+        echo " "(set_color green)"✔"(set_color normal)"  Reviewed "(set_color brblack)"($round/$max_rounds)"(set_color normal)"  $status_line"(set_color brblack)"$time_str"(set_color normal)
 
         # --- triage phase ---
         set -l review_files
@@ -311,7 +313,8 @@ function review_auto
             set -l mins (math "floor($elapsed / 60)")
             set -l secs (math "$elapsed % 60")
             set -l time_str (printf "%d:%02d" $mins $secs)
-            printf "\r %s%s%s  Triage  %s%s%s" $dim $spinner_frames[$frame_idx] $reset $dim $time_str $reset
+            set -l dots (printf "%-3s" $dot_frames[$frame_idx])
+            printf "\r %s·%s  Triaging%s %s%s%s" (set_color $dot_colors[$frame_idx]) $reset "$dots" $dim $time_str $reset
 
             set -l phase_elapsed (math (date +%s) - $triage_start)
             if test $phase_elapsed -ge $phase_timeout
@@ -321,8 +324,8 @@ function review_auto
                 return 1
             end
 
-            set frame_idx (math "$frame_idx % 10 + 1")
-            sleep 0.05 # ~20 FPS for smooth spinner animation
+            set frame_idx (math "$frame_idx % 4 + 1")
+            sleep 0.3
         end
         set -l elapsed (math (date +%s) - $round_start)
         set -l mins (math "floor($elapsed / 60)")
@@ -339,7 +342,7 @@ function review_auto
         end
 
         printf "\r                                                           \r"
-        echo " "(set_color green)"✔"(set_color normal)"  Triage  "(set_color brblack)"$time_str"(set_color normal)
+        echo " "(set_color green)"✔"(set_color normal)"  Triaged  "(set_color brblack)"$time_str"(set_color normal)
 
         # check triage result - trim whitespace and match robustly
         if string match -qr '^\s*NO_ISSUES_FOUND\s*$' < $round_dir/triage.md 2>/dev/null
@@ -377,25 +380,26 @@ function review_auto
             set -l mins (math "floor($elapsed / 60)")
             set -l secs (math "$elapsed % 60")
             set -l time_str (printf "%d:%02d" $mins $secs)
-            printf "\r %s%s%s  Address  %s%s%s" $dim $spinner_frames[$frame_idx] $reset $dim $time_str $reset
+            set -l dots (printf "%-3s" $dot_frames[$frame_idx])
+            printf "\r %s·%s  Fixing%s %s%s%s" (set_color $dot_colors[$frame_idx]) $reset "$dots" $dim $time_str $reset
 
             set -l phase_elapsed (math (date +%s) - $fix_start)
             if test $phase_elapsed -ge $phase_timeout
                 printf "\r                                                           \r"
-                echo " "(set_color red)"✗"(set_color normal)"  Address phase timed out after $phase_timeout seconds in round $round"
+                echo " "(set_color red)"✗"(set_color normal)"  Fix phase timed out after $phase_timeout seconds in round $round"
                 wezterm cli kill-pane --pane-id $work_pane &>/dev/null
                 return 1
             end
 
-            set frame_idx (math "$frame_idx % 10 + 1")
-            sleep 0.05 # ~20 FPS for smooth spinner animation
+            set frame_idx (math "$frame_idx % 4 + 1")
+            sleep 0.3
         end
         set -l elapsed (math (date +%s) - $round_start)
         set -l mins (math "floor($elapsed / 60)")
         set -l secs (math "$elapsed % 60")
         set -l time_str (printf "%d:%02d" $mins $secs)
         printf "\r                                                           \r"
-        echo " "(set_color green)"✔"(set_color normal)"  Address  "(set_color brblack)"$time_str"(set_color normal)
+        echo " "(set_color green)"✔"(set_color normal)"  Fixed  "(set_color brblack)"$time_str"(set_color normal)
 
         # kill work pane before next round
         wezterm cli kill-pane --pane-id $work_pane &>/dev/null

--- a/fish/.config/fish/functions/review_auto.fish
+++ b/fish/.config/fish/functions/review_auto.fish
@@ -1,0 +1,208 @@
+function review_auto
+    # Usage: review_auto [--max-rounds N] [--provider openai|anthropic] [--panes 1-4] [--dry-run]
+    set -l max_rounds 3
+    set -l provider anthropic
+    set -l num_panes 4
+    set -l dry_run false
+
+    set -l i 1
+    while test $i -le (count $argv)
+        switch $argv[$i]
+            case --max-rounds
+                set i (math $i + 1)
+                set max_rounds $argv[$i]
+            case --provider
+                set i (math $i + 1)
+                set provider (string lower $argv[$i])
+            case --panes
+                set i (math $i + 1)
+                set num_panes $argv[$i]
+            case --dry-run
+                set dry_run true
+            case '*'
+                echo "Unknown argument: $argv[$i]"
+                echo "Usage: review_auto [--max-rounds N] [--provider openai|anthropic] [--panes 1-4] [--dry-run]"
+                return 1
+        end
+        set i (math $i + 1)
+    end
+
+    if test $num_panes -lt 1 -o $num_panes -gt 4
+        echo "Pane count must be between 1 and 4"
+        return 1
+    end
+
+    set -l pr_number (gh pr view --json number -q .number 2>/dev/null)
+    if test -z "$pr_number"
+        echo "No PR found for current branch"
+        return 1
+    end
+
+    set -l review_model gpt-5.4-high
+    set -l triage_model gpt-5.4-high
+    set -l fix_model claude-4.6-opus
+    switch $provider
+        case anthropic
+            set review_model claude-4.6-opus
+            set triage_model claude-4.6-opus
+        case openai
+            set fix_model gpt-5.4-high
+    end
+
+    set -l session_dir (mktemp -d /tmp/review_auto.XXXXXX)
+    set -l review_cmd "cursor-agent --yolo --print --trust --model $review_model -p"
+
+    # reviewer identities and prompts
+    set -l names Evelyn Vivian Stella Tiffany
+    set -l prompts \
+        "You are Evelyn. Use the local review skill to review PR #$pr_number in read-only mode and follow its exact response format." \
+        "You are Vivian. Use the local review skill to review PR #$pr_number in read-only mode and follow its exact response format." \
+        "You are Stella. Use the local review skill to review PR #$pr_number in read-only mode and follow its exact response format. Focus on critical bugs, security vulnerabilities, and logic errors." \
+        "You are Tiffany. Use the local review skill to review PR #$pr_number in read-only mode and follow its exact response format. Focus on dead code, unused imports, and unreachable code paths."
+
+    echo "┌─────────────────────────────────────────────┐"
+    echo "│  review_auto — PR #$pr_number"
+    echo "│  provider: $provider | panes: $num_panes | max rounds: $max_rounds"
+    echo "│  session: $session_dir"
+    echo "└─────────────────────────────────────────────┘"
+
+    # --- split panes: orchestrator on top, reviewers on bottom ---
+    set -l pane_0 $WEZTERM_PANE
+    set -l pane_ids
+
+    set pane_ids (wezterm cli split-pane --pane-id $pane_0 --bottom --percent 70)
+    if test $num_panes -ge 2
+        set -a pane_ids (wezterm cli split-pane --pane-id $pane_ids[1] --right)
+    end
+    if test $num_panes -ge 3
+        set -a pane_ids (wezterm cli split-pane --pane-id $pane_ids[1] --right)
+    end
+    if test $num_panes -ge 4
+        set -a pane_ids (wezterm cli split-pane --pane-id $pane_ids[2] --right)
+    end
+
+    # pane_ids is now: [bottom-left, bottom-right, bottom-left-center, bottom-right-center]
+    # reorder to match reviewer indices 1..num_panes
+    switch $num_panes
+        case 1
+            # pane_ids = [p1]
+        case 2
+            # pane_ids = [p1, p2] — already correct
+        case 3
+            # splits: p1(left full), p2(right half of original), p3(right half of p1)
+            # actual order left→right: p1-remaining, p3, p2
+            set pane_ids $pane_ids[1] $pane_ids[3] $pane_ids[2]
+        case 4
+            # splits: p1(left half), p2(right half), p3(right of p1→center-left), p4(right of p2→center-right)
+            # actual order left→right: p1-remaining, p3, p2-remaining, p4
+            set pane_ids $pane_ids[1] $pane_ids[3] $pane_ids[2] $pane_ids[4]
+    end
+
+    # --- main loop ---
+    set -l round 1
+    while test $round -le $max_rounds
+        set -l round_dir $session_dir/round_$round
+        mkdir -p $round_dir
+
+        echo ""
+        echo "═══════════════════════════════════════════════"
+        echo "  ROUND $round / $max_rounds — REVIEW PHASE"
+        echo "═══════════════════════════════════════════════"
+
+        # clean sentinel files
+        for j in (seq $num_panes)
+            set -l name (string lower $names[$j])
+            rm -f $round_dir/.done_$name
+        end
+
+        # dispatch review agents to panes
+        for j in (seq $num_panes)
+            set -l name (string lower $names[$j])
+            set -l cmd "$review_cmd \"$prompts[$j]\" 2>&1 | tee $round_dir/review_$name.md; touch $round_dir/.done_$name"
+            printf '%s\r' "$cmd" | wezterm cli send-text --no-paste --pane-id $pane_ids[$j]
+        end
+
+        # poll for all reviewers to finish
+        echo "  Waiting for $num_panes reviewer(s)..."
+        while true
+            set -l done_count 0
+            for j in (seq $num_panes)
+                set -l name (string lower $names[$j])
+                if test -f $round_dir/.done_$name
+                    set done_count (math $done_count + 1)
+                end
+            end
+            if test $done_count -ge $num_panes
+                break
+            end
+            sleep 5
+        end
+        echo "  All reviewers finished."
+
+        # --- triage phase ---
+        echo ""
+        echo "───────────────────────────────────────────────"
+        echo "  ROUND $round / $max_rounds — TRIAGE PHASE"
+        echo "───────────────────────────────────────────────"
+
+        set -l review_files
+        for j in (seq $num_panes)
+            set -l name (string lower $names[$j])
+            set -a review_files "$round_dir/review_$name.md"
+        end
+        set -l file_list (string join ", " $review_files)
+
+        set -l triage_prompt "You are a senior code-review triage agent. Read the review output files at: $file_list
+
+Your job:
+- Read all review files using the Read tool
+- Filter out nitpicks, style-only comments, and false positives
+- Output ONLY the issues that are real bugs, logic errors, security vulnerabilities, or missing error handling
+- If a review file is empty or contains an error, skip it
+- If there are no real issues, output exactly the string: NO_ISSUES_FOUND
+- Format each real issue as: file path, line number, severity (critical/high/medium), and description"
+
+        cursor-agent --yolo --print --trust --model $triage_model -p "$triage_prompt" 2>&1 | tee $round_dir/triage.md
+
+        # check triage result
+        if grep -q "NO_ISSUES_FOUND" $round_dir/triage.md
+            echo ""
+            echo "┌─────────────────────────────────────────────┐"
+            echo "│  CLEAN — no real issues found in round $round"
+            echo "│  PR #$pr_number is good to go."
+            echo "│  Session: $session_dir"
+            echo "└─────────────────────────────────────────────┘"
+            return 0
+        end
+
+        if test "$dry_run" = true
+            echo ""
+            echo "┌─────────────────────────────────────────────┐"
+            echo "│  DRY RUN — issues found but skipping fix"
+            echo "│  Triage output: $round_dir/triage.md"
+            echo "│  Session: $session_dir"
+            echo "└─────────────────────────────────────────────┘"
+            return 0
+        end
+
+        # --- fix phase ---
+        echo ""
+        echo "───────────────────────────────────────────────"
+        echo "  ROUND $round / $max_rounds — FIX PHASE"
+        echo "───────────────────────────────────────────────"
+
+        set -l fix_prompt "You are a senior engineer. Read the triaged code-review issues at $round_dir/triage.md using the Read tool. Fix every issue listed. Do not fix anything not listed. After fixing, commit your changes with a clear message referencing what was fixed."
+
+        cursor-agent --yolo --print --trust --model $fix_model -p "$fix_prompt" 2>&1 | tee $round_dir/fix.md
+
+        set round (math $round + 1)
+    end
+
+    echo ""
+    echo "┌─────────────────────────────────────────────┐"
+    echo "│  MAX ROUNDS ($max_rounds) reached for PR #$pr_number"
+    echo "│  Review the last round's output manually."
+    echo "│  Session: $session_dir"
+    echo "└─────────────────────────────────────────────┘"
+    return 1
+end

--- a/fish/.config/fish/functions/review_auto.fish
+++ b/fish/.config/fish/functions/review_auto.fish
@@ -90,7 +90,7 @@ function review_auto
     end
 
     set -l session_dir (mktemp -d /tmp/review_auto.XXXXXX)
-    set -l review_cmd "cursor-agent --yolo --model $review_model -p"
+    set -l review_cmd "cursor-agent --yolo --model $review_model"
 
     # reviewer identities and prompts
     set -l names Evelyn Vivian Stella
@@ -228,7 +228,7 @@ function review_auto
             set -l sentinel "$iter_dir/.done_$name"
             set -l prompt "$base_prompts[$j] IMPORTANT: When done, write your complete review to $outfile using the Write tool. Then run this shell command: touch $sentinel"
             set -l prompt_file "$iter_dir/prompt_review_$name.txt"
-            printf '%s' "$prompt" > $prompt_file
+            printf '%s' "$prompt" >$prompt_file
             set -l cmd "$review_cmd \"\$(cat $prompt_file)\""
             printf '%s\r' "$cmd" | wezterm cli send-text --no-paste --pane-id $pane_ids[$j]
             sleep 0.5 # stagger to avoid cli-config.json race condition
@@ -305,7 +305,7 @@ function review_auto
         set -l triage_prompt "You are a code-review triage agent. Read the review output files at: $file_list. Read all review files using the Read tool. Filter out nitpicks, style-only comments, and false positives. Identify ONLY real bugs, logic errors, security vulnerabilities, or missing error handling. If a review file is empty or contains an error, skip it. Write your verdict to $iter_dir/triage.md. If there are NO real issues: write ONLY the text NO_ISSUES_FOUND (nothing else, just that one line). If there ARE real issues: write each issue with file path, line number, severity (critical/high/medium), and description. Do NOT include the string NO_ISSUES_FOUND anywhere. When completely done, run this shell command: touch $triage_sentinel"
 
         set -l triage_prompt_file "$iter_dir/prompt_triage.txt"
-        printf '%s' "$triage_prompt" > $triage_prompt_file
+        printf '%s' "$triage_prompt" >$triage_prompt_file
         set -l triage_cmd "cursor-agent --yolo --model $triage_model \"\$(cat $triage_prompt_file)\""
         printf '%s\r' "$triage_cmd" | wezterm cli send-text --no-paste --pane-id $work_pane
 
@@ -347,7 +347,7 @@ function review_auto
         # check triage result - collapse into a single string so multi-line files
         # are compared atomically instead of per-line via fish list semantics
         set -l _triage_content (cat $iter_dir/triage.md 2>/dev/null | string collect | string trim)
-        if test "$_triage_content" = "NO_ISSUES_FOUND"
+        if test "$_triage_content" = NO_ISSUES_FOUND
             echo " "(set_color green)"✔"(set_color normal)" No issues found"
             set -l total_dur (math (date +%s) - $session_start)
             set -l total_dur_m (math "floor($total_dur / 60)")
@@ -383,7 +383,7 @@ function review_auto
         set -l fix_prompt "Read the triaged code-review issues at $iter_dir/triage.md using the Read tool. Fix every issue listed. Do not fix anything not listed. After fixing, commit your changes with a clear message referencing what was fixed, then push to the remote branch with git push. Then use the /pr skill to update the PR title and description. When completely done, run this shell command: touch $fix_sentinel"
 
         set -l fix_prompt_file "$iter_dir/prompt_fix.txt"
-        printf '%s' "$fix_prompt" > $fix_prompt_file
+        printf '%s' "$fix_prompt" >$fix_prompt_file
         set -l fix_cmd "cursor-agent --yolo --model $fix_model \"\$(cat $fix_prompt_file)\""
         printf '%s\r' "$fix_cmd" | wezterm cli send-text --no-paste --pane-id $work_pane
 

--- a/fish/.config/fish/functions/review_auto.fish
+++ b/fish/.config/fish/functions/review_auto.fish
@@ -74,29 +74,38 @@ function review_auto
     # ├───────────┬─────────┴───────┬─────────────┤
     # │ Vivian    │    Stella       │   Tiffany   │
     # └───────────┴─────────────────┴─────────────┘
+    #
+    # Split order matters! Must split top/bottom FIRST (while pane is full width),
+    # then split each row horizontally.
     set -l pane_0 $WEZTERM_PANE
     set -l pane_ids
 
-    # Evelyn always goes top-right
+    # First: split top/bottom to create the two rows
+    set -l pane_bottom (wezterm cli split-pane --pane-id $pane_0 --bottom)
+
+    # Now split the top row: orchestrator | Evelyn
     set -l pane_evelyn (wezterm cli split-pane --pane-id $pane_0 --right)
     set pane_ids $pane_evelyn
 
     if test $num_panes -ge 2
-        # Vivian: bottom-left (split orchestrator down)
-        set -l pane_vivian (wezterm cli split-pane --pane-id $pane_0 --bottom)
-        set -a pane_ids $pane_vivian
+        # Vivian is already in pane_bottom (bottom-left after we split it)
+        # But we need to track it - it's pane_bottom itself for now
+        set -a pane_ids $pane_bottom
 
         if test $num_panes -ge 3
-            # Stella: bottom-right (split Vivian right)
-            set -l pane_stella (wezterm cli split-pane --pane-id $pane_vivian --right)
+            # Split bottom row: Vivian | Stella
+            set -l pane_stella (wezterm cli split-pane --pane-id $pane_bottom --right)
             set -a pane_ids $pane_stella
 
             if test $num_panes -ge 4
-                # Tiffany: bottom-far-right (split Stella right)
+                # Split again: Vivian | Stella | Tiffany
                 set -l pane_tiffany (wezterm cli split-pane --pane-id $pane_stella --right)
                 set -a pane_ids $pane_tiffany
             end
         end
+    else
+        # Only 1 reviewer (Evelyn) - kill the unused bottom pane
+        wezterm cli kill-pane --pane-id $pane_bottom
     end
 
     # --- main loop ---

--- a/fish/.config/fish/functions/review_auto.fish
+++ b/fish/.config/fish/functions/review_auto.fish
@@ -200,12 +200,14 @@ function review_auto
 Your job:
 - Read all review files using the Read tool
 - Filter out nitpicks, style-only comments, and false positives
-- Output ONLY the issues that are real bugs, logic errors, security vulnerabilities, or missing error handling
+- Identify ONLY real bugs, logic errors, security vulnerabilities, or missing error handling
 - If a review file is empty or contains an error, skip it
-- If there are no real issues, output exactly the string: NO_ISSUES_FOUND
-- Format each real issue as: file path, line number, severity (critical/high/medium), and description
-- IMPORTANT: Write your final verdict to $round_dir/triage.md using the Write tool. Include NO_ISSUES_FOUND in that file if there are none.
-- When completely done, run: touch $triage_sentinel" > $triage_prompt_file
+
+IMPORTANT - Write your verdict to $round_dir/triage.md:
+- If there are NO real issues: write ONLY the text 'NO_ISSUES_FOUND' (nothing else, just that one line)
+- If there ARE real issues: write each issue with file path, line number, severity (critical/high/medium), and description. Do NOT include the string NO_ISSUES_FOUND anywhere.
+
+When completely done, run: touch $triage_sentinel" > $triage_prompt_file
 
         set -l triage_cmd "cursor-agent --yolo --model $triage_model \"Read the prompt at $triage_prompt_file and follow its instructions exactly.\""
         printf '%s\r' "$triage_cmd" | wezterm cli send-text --no-paste --pane-id $work_pane
@@ -228,8 +230,8 @@ Your job:
         echo "   "(set_color white)"●"(set_color normal)"  triage  "(set_color brblack)"$time_str"(set_color normal)
         echo ""
 
-        # check triage result
-        if grep -q NO_ISSUES_FOUND $round_dir/triage.md 2>/dev/null
+        # check triage result - must be on its own line to avoid false matches
+        if grep -qx NO_ISSUES_FOUND $round_dir/triage.md 2>/dev/null
             echo "   "(set_color green)"●"(set_color normal)"  "(set_color --bold)"clean"(set_color normal)" "(set_color brblack)"— no issues found"(set_color normal)
             echo ""
             return 0

--- a/homebrew/Brewfile
+++ b/homebrew/Brewfile
@@ -38,3 +38,4 @@ cask "codex"
 # https://forum.cursor.com/t/cursor-agent-merkle-tree-napi-darwin-arm64-node-not-opened/155056
 cask "cursor-cli"
 cask "vlc"
+cask "wezterm"


### PR DESCRIPTION
## Summary
Adds `review_auto`, a fish function that automates the code review loop: dispatches review agents in parallel wezterm panes, triages findings, applies fixes, and re-reviews — all hands-free with a configurable round cap.

## Commentary
Includes a design spec at `docs/spec/2026-04-12-review-auto.md` with feasibility findings from testing `cursor-agent --print` and `wezterm cli` pane mechanics. The function reuses the same reviewer identities (Evelyn, Vivian, Stella) and review skill from the existing `review.fish`.

Key implementation details:
- Prompts are written to temp files and read via `$(cat ...)` to avoid shell metacharacter injection in `send-text` commands
- Triage result check uses `string collect | string trim` to collapse the file into a single string, then compares with an exact equality test for robust `NO_ISSUES_FOUND` detection
- Explicit guard ensures `triage.md` exists and is non-empty before entering the fix phase, preventing the fix agent from operating on missing or empty triage output
- PR metadata (number, url, title) parsed via `gh --jq` instead of fragile regex on raw JSON, safely handling special characters in PR titles
- Supports `--provider`, `--panes`, `--max-rounds`, `--timeout`, and `--dry-run` flags
- Validates `--max-rounds`, `--panes`, and `--timeout` as positive integers to prevent undefined behavior
- Validates pane IDs after each `wezterm cli split-pane` call, cleaning up already-created panes on failure to prevent silent dispatch to invalid pane IDs
- All sentinel polling loops (review, triage, fix) have configurable wall-clock timeouts (default 600s) using phase-local elapsed time to prevent indefinite hangs when an agent crashes or fails to touch its sentinel file
- Consistent `set -l` scoping for all local variables across triage and fix phases
- Session temp directory is cleaned up (`rm -rf`) on all exit paths — including early pane-creation failures (Stella pane path now included), timeouts, success, and dry-run — to prevent `/tmp` directory leaks
- Review command includes `-p` flag consistent with `review.fish` to ensure prompts are passed correctly to `cursor-agent`

Made with [Cursor](https://cursor.com)