### PR TITLE
docs: refresh README cursed tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@ This is where I tweak config files till 4am like a goblin. It's pretty cozy in h
 ## My Cursed Tools
 
 - **[Claude Code](https://code.claude.com/)** - This is going to take my job
-- **[Cursor](https://cursor.com/)** - Autocomplete ate my autonomy
 - **[fish](https://fishshell.com/)** - I eat the fish
 - **[homebrew](https://brew.sh/)** - Cyber alcoholic
 - **[neovim](https://neovim.io/)** - Female repellent
@@ -19,5 +18,3 @@ This is where I tweak config files till 4am like a goblin. It's pretty cozy in h
 brew install just
 just init
 ```
-
-`just brew` (run as part of `just init`) clears macOS quarantine on the **cursor-cli** cask so native addons load correctly. If you use `brew bundle` without Just, run `xattr -rd com.apple.quarantine "$(brew --prefix)/Caskroom/cursor-cli/"` afterward. Background: [Cursor forum — merkle-tree NAPI / “not opened” on darwin-arm64](https://forum.cursor.com/t/cursor-agent-merkle-tree-napi-darwin-arm64-node-not-opened/155056).

--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@ This is where I tweak config files till 4am like a goblin. It's pretty cozy in h
 
 ## My Cursed Tools
 
-- **[claude code](https://code.claude.com/)** - This is going to take my job
-- **[cursor cli](https://cursor.com/)** - headless job thief
+- **[claude](https://code.claude.com/)** - this is going to take my job
+- **[cursor](https://cursor.com/)** - this is also going to take my job 
 - **[fish](https://fishshell.com/)** - I eat the fish
-- **[homebrew](https://brew.sh/)** - Cyber alcoholic
-- **[neovim](https://neovim.io/)** - Female repellent
+- **[homebrew](https://brew.sh/)** - cyber alcoholic
+- **[neovim](https://neovim.io/)** - female repellent
 - **[wezterm](https://wezterm.org/index.html)** - lua lua lua
 - **[stow](https://www.gnu.org/software/stow/)** - link those symmies
 

--- a/README.md
+++ b/README.md
@@ -6,17 +6,46 @@ This is where I tweak config files till 4am like a goblin. It's pretty cozy in h
 
 ## My Cursed Tools
 
-- **[claude](https://code.claude.com/)** - This is going to take my job
-- **[fish](https://fishshell.com/)** - I eat the fish
-- **[homebrew](https://brew.sh/)** - Cyber alcoholic
-- **[neovim](https://neovim.io/)** - Female repellent
-- **[wezterm](https://wezterm.org/index.html)** - lua lua lua
-- **[stow](https://www.gnu.org/software/stow/)** - link those symmies
+- **[Claude Code](https://code.claude.com/)** — This is going to take my job
+- **[Cursor](https://cursor.com/)** — Agent + CLI; see setup note on macOS quarantine below
+- **[fish](https://fishshell.com/)** — I eat the fish
+- **[Homebrew](https://brew.sh/)** — Cyber alcoholic
+- **[Neovim](https://neovim.io/)** — LazyVim-flavored (`lazyvim.json` in-tree)
+- **[WezTerm](https://wezterm.org/index.html)** — lua lua lua
+- **[GNU Stow](https://www.gnu.org/software/stow/)** — link those symmies
+
+Full formula/cask list lives in [`homebrew/Brewfile`](homebrew/Brewfile).
+
+## What's in this repo
+
+[GNU Stow](https://www.gnu.org/software/stow/) packages (targets `~` when you run `just stow`):
+
+| Package   | What it is                         |
+| --------- | ---------------------------------- |
+| `claude/` | Claude Code config                 |
+| `cursor/` | Cursor CLI config (e.g. skills)    |
+| `fish/`   | Fish shell                         |
+| `nvim/`   | Neovim / LazyVim                   |
+| `wezterm/`| WezTerm                            |
+
+Also: `docs/` (notes/specs), `pickpocket.json` (pinned checkouts for the **pickpocket** CLI from Homebrew), and [`justfile`](justfile) for bootstrap.
 
 ## Setup
+
+Install [just](https://github.com/casey/just) first (e.g. `brew install just`), then:
+
 ```bash
-brew install just
+git clone https://github.com/wu-json/dots.git
+cd dots
 just init
 ```
 
-`just brew` (run as part of `just init`) clears macOS quarantine on the **cursor-cli** cask so native addons load correctly. If you use `brew bundle` without Just, run `xattr -rd com.apple.quarantine "$(brew --prefix)/Caskroom/cursor-cli/"` afterward. Background: [Cursor forum — merkle-tree NAPI / “not opened” on darwin-arm64](https://forum.cursor.com/t/cursor-agent-merkle-tree-napi-darwin-arm64-node-not-opened/155056).
+`just init` runs, in order:
+
+1. **`just brew`** — `brew bundle install` using `homebrew/Brewfile`. On macOS, if the **cursor-cli** cask is present, it clears Gatekeeper quarantine on that install so native addons (e.g. merkle-tree NAPI) load. If you use `brew bundle` without Just, run `xattr -rd com.apple.quarantine "$(brew --prefix)/Caskroom/cursor-cli/"` afterward. Background: [Cursor forum — merkle-tree NAPI / “not opened” on darwin-arm64](https://forum.cursor.com/t/cursor-agent-merkle-tree-napi-darwin-arm64-node-not-opened/155056).
+2. **`just stow`** — Symlinks the packages above into your home directory.
+3. **`just init-fish`** — Appends Homebrew’s `fish` to `/etc/shells` (with `sudo` if needed) and runs `chsh` so fish is your login shell.
+
+If you do not want to change your login shell, run `just brew` and `just stow` only.
+
+The `justfile` uses `/opt/homebrew` on macOS and `/home/linuxbrew/.linuxbrew` on Linux for Homebrew paths.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This is where I tweak config files till 4am like a goblin. It's pretty cozy in h
 
 ## My Cursed Tools
 
-- **[Claude Code](https://code.claude.com/)** - This is going to take my job
+- **[claude code](https://code.claude.com/)** - This is going to take my job
 - **[fish](https://fishshell.com/)** - I eat the fish
 - **[homebrew](https://brew.sh/)** - Cyber alcoholic
 - **[neovim](https://neovim.io/)** - Female repellent

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This is where I tweak config files till 4am like a goblin. It's pretty cozy in h
 ## My Cursed Tools
 
 - **[claude code](https://code.claude.com/)** - This is going to take my job
+- **[cursor cli](https://cursor.com/)** - headless job thief
 - **[fish](https://fishshell.com/)** - I eat the fish
 - **[homebrew](https://brew.sh/)** - Cyber alcoholic
 - **[neovim](https://neovim.io/)** - Female repellent

--- a/README.md
+++ b/README.md
@@ -6,46 +6,18 @@ This is where I tweak config files till 4am like a goblin. It's pretty cozy in h
 
 ## My Cursed Tools
 
-- **[Claude Code](https://code.claude.com/)** — This is going to take my job
-- **[Cursor](https://cursor.com/)** — Agent + CLI; see setup note on macOS quarantine below
-- **[fish](https://fishshell.com/)** — I eat the fish
-- **[Homebrew](https://brew.sh/)** — Cyber alcoholic
-- **[Neovim](https://neovim.io/)** — LazyVim-flavored (`lazyvim.json` in-tree)
-- **[WezTerm](https://wezterm.org/index.html)** — lua lua lua
-- **[GNU Stow](https://www.gnu.org/software/stow/)** — link those symmies
-
-Full formula/cask list lives in [`homebrew/Brewfile`](homebrew/Brewfile).
-
-## What's in this repo
-
-[GNU Stow](https://www.gnu.org/software/stow/) packages (targets `~` when you run `just stow`):
-
-| Package   | What it is                         |
-| --------- | ---------------------------------- |
-| `claude/` | Claude Code config                 |
-| `cursor/` | Cursor CLI config (e.g. skills)    |
-| `fish/`   | Fish shell                         |
-| `nvim/`   | Neovim / LazyVim                   |
-| `wezterm/`| WezTerm                            |
-
-Also: `docs/` (notes/specs), `pickpocket.json` (pinned checkouts for the **pickpocket** CLI from Homebrew), and [`justfile`](justfile) for bootstrap.
+- **[Claude Code](https://code.claude.com/)** - This is going to take my job
+- **[Cursor](https://cursor.com/)** - Autocomplete ate my autonomy
+- **[fish](https://fishshell.com/)** - I eat the fish
+- **[homebrew](https://brew.sh/)** - Cyber alcoholic
+- **[neovim](https://neovim.io/)** - Female repellent
+- **[wezterm](https://wezterm.org/index.html)** - lua lua lua
+- **[stow](https://www.gnu.org/software/stow/)** - link those symmies
 
 ## Setup
-
-Install [just](https://github.com/casey/just) first (e.g. `brew install just`), then:
-
 ```bash
-git clone https://github.com/wu-json/dots.git
-cd dots
+brew install just
 just init
 ```
 
-`just init` runs, in order:
-
-1. **`just brew`** — `brew bundle install` using `homebrew/Brewfile`. On macOS, if the **cursor-cli** cask is present, it clears Gatekeeper quarantine on that install so native addons (e.g. merkle-tree NAPI) load. If you use `brew bundle` without Just, run `xattr -rd com.apple.quarantine "$(brew --prefix)/Caskroom/cursor-cli/"` afterward. Background: [Cursor forum — merkle-tree NAPI / “not opened” on darwin-arm64](https://forum.cursor.com/t/cursor-agent-merkle-tree-napi-darwin-arm64-node-not-opened/155056).
-2. **`just stow`** — Symlinks the packages above into your home directory.
-3. **`just init-fish`** — Appends Homebrew’s `fish` to `/etc/shells` (with `sudo` if needed) and runs `chsh` so fish is your login shell.
-
-If you do not want to change your login shell, run `just brew` and `just stow` only.
-
-The `justfile` uses `/opt/homebrew` on macOS and `/home/linuxbrew/.linuxbrew` on Linux for Homebrew paths.
+`just brew` (run as part of `just init`) clears macOS quarantine on the **cursor-cli** cask so native addons load correctly. If you use `brew bundle` without Just, run `xattr -rd com.apple.quarantine "$(brew --prefix)/Caskroom/cursor-cli/"` afterward. Background: [Cursor forum — merkle-tree NAPI / “not opened” on darwin-arm64](https://forum.cursor.com/t/cursor-agent-merkle-tree-napi-darwin-arm64-node-not-opened/155056).


### PR DESCRIPTION
## Summary
Refresh the README “My Cursed Tools” list: add **cursor** under **claude**, lowercase several taglines, and drop the long macOS **cursor-cli** quarantine note so setup stays a short `just` snippet.

## Commentary
Quarantine / `xattr` guidance remains in the `justfile` and `homebrew/Brewfile` comments for anyone who needs it.