### PR TITLE
fix: truncate long commit messages in review_auto Fixed line

### DIFF
--- a/fish/.config/fish/functions/review_auto.fish
+++ b/fish/.config/fish/functions/review_auto.fish
@@ -411,6 +411,13 @@ function review_auto
         end
         printf "\r                                                           \r"
         set -l _commit_msg (git log -1 --format='%s' 2>/dev/null)
+        set -l _fix_max (math $COLUMNS - 12)
+        if test $_fix_max -lt 20
+            set _fix_max 20
+        end
+        if test (string length "$_commit_msg") -gt $_fix_max
+            set _commit_msg (string sub -l $_fix_max "$_commit_msg")"…"
+        end
         echo " "(set_color green)"✔"(set_color normal)" Fixed "(set_color brblack)"$_commit_msg"(set_color normal)
 
         # kill work pane before next iteration


### PR DESCRIPTION
## Summary
- The `✔ Fixed <commit msg>` status line in `review_auto` wraps when commit messages are long, which looks ugly
- Truncate the commit message to fit within `$COLUMNS - 12` (accounting for the ` ✔ Fixed ` prefix), appending `…` when truncated
- Matches the existing truncation pattern already used for the PR title in the header