### PR TITLE
chore: remove vimwiki plugin

### DIFF
--- a/nvim/.config/nvim/lazy-lock.json
+++ b/nvim/.config/nvim/lazy-lock.json
@@ -45,6 +45,5 @@
   "ts-comments.nvim": { "branch": "main", "commit": "123a9fb12e7229342f807ec9e6de478b1102b041" },
   "typescript-tools.nvim": { "branch": "master", "commit": "c2f5910074103705661e9651aa841e0d7eea9932" },
   "vim-bufonly": { "branch": "master", "commit": "05a9f2d79f7aa7e2a94f9a6e29555e878e88d411" },
-  "vimwiki": { "branch": "dev", "commit": "72792615e739d0eb54a9c8f7e0a46a6e2407c9e8" },
   "which-key.nvim": { "branch": "main", "commit": "3aab2147e74890957785941f0c1ad87d0a44c15a" }
 }

--- a/nvim/.config/nvim/lua/plugins/tools.lua
+++ b/nvim/.config/nvim/lua/plugins/tools.lua
@@ -54,25 +54,6 @@ return {
     },
   },
   {
-    "vimwiki/vimwiki",
-    keys = {
-      { "<leader>ww", desc = "Open vimwiki index" },
-      { "<leader>wd", "<cmd>VimwikiMakeDiaryNote<cr>", desc = "Open vimwiki diary" },
-      { "<leader>wi", "<cmd>VimwikiDiaryIndex<cr>", desc = "Open vimwiki diary index" },
-    },
-    init = function()
-      vim.g.vimwiki_list = {
-        {
-          path = "~/vimwiki/",
-          syntax = "markdown",
-          ext = ".md",
-          auto_diary_index = 1,
-        },
-      }
-      vim.g.vimwiki_global_ext = 0 -- Don't hijack all .md files
-    end,
-  },
-  {
     "sotte/presenting.nvim",
     opts = {
       -- fill in your options here


### PR DESCRIPTION
## Summary
Remove the vimwiki plugin from the Neovim configuration, including its plugin spec in `tools.lua` and its lock entry in `lazy-lock.json`.