### PR TITLE
fix(pi): bump Ollama context window to 200k

### DIFF
--- a/pi/.pi/agent/extensions/ollama-providers.ts
+++ b/pi/.pi/agent/extensions/ollama-providers.ts
@@ -29,8 +29,8 @@ const MODELS: LocalModel[] = [
 	{
 		id: "qwen3.6:35b-a3b-coding-mxfp8",
 		name: "Qwen3.6 35B A3B Coding (mxfp8)",
-		// Qwen3 ships with 32k native context; bump if you've enabled YaRN.
-		contextWindow: 32768,
+		// Qwen3 ships with 32k native context; bumped to 200k for pi agent's extended context needs.
+		contextWindow: 200000,
 		maxTokens: 4096,
 		reasoning: true,
 	},


### PR DESCRIPTION
## Summary
Bumped the Ollama provider's context window from 32k (32,768) to 200k (200,000) tokens for the pi agent, giving it much more room for extended conversations and tool output.

## Commentary
The comment in the code noted that Qwen3 ships with 32k native context. Updated to 200k aligns with typical extended-context setups for LLM agents that need to handle large tool responses and extended reasoning chains.