### PR TITLE
feat: add model aliases (opus, qwen) for review/review_auto functions

### DIFF
--- a/docs/wu-json/specs/archived/2026-04-26-review-model-aliases.md
+++ b/docs/wu-json/specs/archived/2026-04-26-review-model-aliases.md
@@ -1,0 +1,102 @@
+---
+status: implemented
+---
+
+# Short Model Aliases for review / review_auto
+
+**Date:** 2026-04-26
+**Author:** Jason Wu
+**Status:** Implemented
+
+## Problem
+
+The `review` and `review_auto` fish functions accept `--model PATTERN` with the full provider/model string (e.g. `anthropic/claude-opus-4-7` or `ollama-tailnet/qwen3.6:35b-a3b-coding-mxfp8`). You currently switch between:
+
+- `anthropic/claude-opus-4-7` (Opus 4.7)
+- `ollama-tailnet/qwen3.6:35b-a3b-coding-mxfp8` (Qwen 3.6 on tailnet)
+
+Typed repeatedly — `review --model ollama-tailnet/qwen3.6:35b-a3b-coding-mxfp8` — this is tedious.
+
+## Goal
+
+Allow short, memorable aliases for model providers so common models can be invoked with minimal typing:
+
+```fish
+review --model opus            # → anthropic/claude-opus-4-7
+review --model qwen            # → ollama-tailnet/qwen3.6:...
+review --model opus --agents 3       # aliases work with any other flags
+```
+
+## Design
+
+### 1. Colocated alias definitions & resolver
+
+Aliases are defined inside both `review.fish` and `review_auto.fish` using a `switch` statement. This is the most reliable approach in fish since indirect variable expansion (`$$`) works correctly in bash but not cleanly in fish (fish uses `$$` for PID). A switch is simple, explicit, and self-documenting.
+
+Each function gets this right after argument parsing, before the model is used:
+
+```fish
+switch $model_override
+    case ''
+        # Empty — no alias resolution needed, skip to assignment below
+    case opus
+        set model_override "anthropic/claude-opus-4-7"
+    case qwen
+        set model_override "ollama-tailnet/qwen3.6:35b-a3b-coding-mxfp8"
+    case '*'
+        # Not a recognized alias — check if it's a full provider string (contains '/')
+        if not string match -q '*/*' -- $model_override
+            echo "Unknown model alias: '$model_override'" >&2
+            echo "Full provider strings (containing '/') are passed through as-is." >&2
+            echo "Available aliases: opus, qwen" >&2
+            return 1
+        end
+        # Full provider string — no conversion needed; fall through
+end
+
+# Assign the resolved (or pass-through) value to model
+if test -n "$model_override"
+    set model $model_override
+end
+```
+
+### 2. Help output update
+
+In the `--help` block of both functions, add an **Aliases** section showing the actual provider strings:
+
+```fish
+echo "Aliases:"
+echo "   opus         → anthropic/claude-opus-4-7"
+echo "   qwen         → ollama-tailnet/qwen3.6:35b-a3b-coding-mxfp8"
+echo "   Full provider strings (e.g. openai/gpt-5.5-high) are passed through as-is."
+```
+
+### 3. Charset guard (unchanged)
+
+The existing charset guard regex (`'^[A-Za-z0-9._/:-]+$'`) continues to validate `--model` values before alias resolution happens. It accepts both aliases and full provider strings. No change needed here.
+
+## Non-goals
+
+- Dynamic provider/model discovery (no auto-scanning of installed providers).
+- Changing the default model (still `anthropic/claude-opus-4-7`).
+- Per-user configurable aliases (e.g. via `config.local.fish`). Colocated aliases are hardcoded in the functions, which limits extensibility but keeps things simple and in one place. This tradeoff is accepted because adding 2–3 common aliases rarely needs extension.
+
+## Scope-out decision
+
+- **Fuzzy/partial matching** (e.g. `opus-4` → `opus`): scoped out. Exact match is fast, unambiguous, and avoids ambiguity (what about `opus4`? `opus-4`?). Can revisit later if needed.
+
+## Implementation steps
+
+1. Add the alias `switch` block into both `review.fish` and `review_auto.fish` right after `model_override` is set (keeping the existing `if test -n` assignment block).
+2. Update the `--help` output in both functions with the Aliases section showing actual provider strings.
+3. Test:
+    - `review --model opus` → uses Claude Opus 4.7
+    - `review --model qwen` → uses Qwen 3.6 on tailnet
+    - `review --model anthropic/claude-opus-4-7` → passes through (no change)
+    - `review --model nonexist` → errors with helpful message
+    - `review --model opus --agents 3` → alias + other flags work together
+    - `review` (no flag) → default model still works
+
+## Open questions
+
+- None — the design is straightforward and the switch approach avoids fish's indirect variable pitfalls.

--- a/fish/.config/fish/functions/review.fish
+++ b/fish/.config/fish/functions/review.fish
@@ -47,6 +47,26 @@ function review
         set i (math $i + 1)
     end
 
+
+    # Resolve model aliases: opus, qwen, or pass through full provider strings
+    switch $model_override
+        case ''
+            # Empty — no alias resolution needed, skip to assignment below
+        case opus
+            set model_override "anthropic/claude-opus-4-7"
+        case qwen
+            set model_override "ollama-tailnet/qwen3.6:35b-a3b-coding-mxfp8"
+        case '*'
+            # Not a recognized alias — check if it's a full provider string (contains '/')
+            if not string match -q '*/*' -- $model_override
+                echo "Unknown model alias: '$model_override'" >&2
+                echo "Full provider strings (containing '/') are passed through as-is." >&2
+                echo "Available aliases: opus, qwen" >&2
+                return 1
+            end
+            # Full provider string — no conversion needed; fall through
+    end
+
     if test $num_panes -lt 1 -o $num_panes -gt 4
         echo "Number of panes must be between 1 and 4"
         return 1
@@ -68,9 +88,16 @@ function review
         echo "   - model is set via --model (default: anthropic/claude-opus-4-7)."
         echo "   - agent count via positional arg 1-4 (default: 1)."
         echo ""
+        echo "Aliases:"
+        echo "   opus          → anthropic/claude-opus-4-7"
+        echo "   qwen          → ollama-tailnet/qwen3.6:35b-a3b-coding-mxfp8"
+        echo "   Full provider strings (e.g. openai/gpt-5.5-high) are passed through as-is."
+        echo ""
         echo "Examples:"
-        echo "  review                                # 1 reviewer (Evelyn), default model"
-        echo "  review 3 --model ollama-local/qwen3.6 # 3 reviewers, local model"
+        echo "  review                                   # 1 reviewer (Evelyn), default model"
+        echo "  review 3 --model opus                    # 3 reviewers, Opus 4.7"
+        echo "  review 3 --model qwen                    # 3 reviewers, Qwen 3.6 on tailnet"
+        echo "  review 3 --model ollama-local/qwen3.6    # 3 reviewers, local model"
         return 0
     end
 

--- a/fish/.config/fish/functions/review_auto.fish
+++ b/fish/.config/fish/functions/review_auto.fish
@@ -77,6 +77,26 @@ function review_auto
         set i (math $i + 1)
     end
 
+
+     # Resolve model aliases: opus, qwen, or pass through full provider strings
+    switch $model_override
+        case ''
+              # Empty — no alias resolution needed, skip to assignment below
+        case opus
+            set model_override "anthropic/claude-opus-4-7"
+        case qwen
+            set model_override "ollama-tailnet/qwen3.6:35b-a3b-coding-mxfp8"
+        case '*'
+              # Not a recognized alias — check if it's a full provider string (contains '/')
+            if not string match -q '*/*' -- $model_override
+                echo "Unknown model alias: '$model_override'" >&2
+                echo "Full provider strings (containing '/') are passed through as-is." >&2
+                echo "Available aliases: opus, qwen" >&2
+                return 1
+            end
+              # Full provider string — no conversion needed; fall through
+    end
+
     if test $num_agents -lt 1 -o $num_agents -gt 3
         echo "Agent count must be between 1 and 3"
         return 1
@@ -103,10 +123,17 @@ function review_auto
         echo "  - max iterations via --max-iterations (default: 10)."
         echo "  - phase timeout via --timeout in seconds (default: 3600, i.e. 1 hour)."
         echo ""
+        echo "Aliases:"
+        echo "   opus             -> anthropic/claude-opus-4-7"
+        echo "   qwen             -> ollama-tailnet/qwen3.6:35b-a3b-coding-mxfp8"
+        echo "   Full provider strings (e.g. openai/gpt-5.5-high) are passed through as-is."
+        echo ""
         echo "Examples:"
-        echo "  review_auto                              # 1 reviewer, 10 iterations"
-        echo "  review_auto --agents 3 --max-iterations 3 # 3 reviewers, up to 3 iterations"
-        echo "  review_auto --model ollama-local/qwen3.6  # use local model"
+        echo "  review_auto                                    # 1 reviewer, 10 iterations"
+        echo "  review_auto --agents 3 --max-iterations 3      # 3 reviewers, up to 3 iterations"
+        echo "  review_auto --model opus                       # Opus 4.7"
+        echo "  review_auto --model qwen                       # Qwen 3.6 on tailnet"
+        echo "  review_auto --model ollama-local/qwen3.6        # use local model"
         return 0
     end
 


### PR DESCRIPTION
## Summary
Add short model aliases (`opus`, `qwen`) to the `review` and `review_auto` fish functions so common model provider strings don't need to be typed in full.

## Commentary
- `opus` maps to `anthropic/claude-opus-4-7`
- `qwen` maps to `ollama-tailnet/qwen3.6:35b-a3b-coding-mxfp8`
- Full provider strings (containing `/`) are passed through unchanged via a `*/*` glob check, so existing usage like `--model anthropic/claude-opus-4-7` keeps working
- Aliases are case-sensitive; unknown aliases produce a clear error listing available ones
- `--help` output documents both aliases and includes updated examples
- Fuzzy/partial matching is scoped out for now; exact match only
- Spec lives under `docs/wu-json/specs/archived/2026-04-26-review-model-aliases.md` and matches the shipped implementation (correct `*/*` glob, status: implemented)
