### PR TITLE
feat: add yazi terminal file manager with dotfiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ This is where I tweak config files till 4am like a goblin. It's pretty cozy in h
 - **[pi](https://github.com/badlogic/pi-mono)** - this is also going to take my job
 - **[wezterm](https://wezterm.org/index.html)** - lua lua lua
 - **[stow](https://www.gnu.org/software/stow/)** - link those symmies
+- **[yazi](https://yazi-rs.github.io/)** - beijing duck
 
 ## Setup
 ```bash

--- a/fish/.config/fish/config.fish
+++ b/fish/.config/fish/config.fish
@@ -29,6 +29,9 @@ alias gho="ghome"
 alias ls="eza"
 alias tree="eza --tree"
 
+# Yazi
+alias y="yazi"
+
 # Obsidian
 alias o="obsidian"
 alias od="obsidian daily"

--- a/homebrew/Brewfile
+++ b/homebrew/Brewfile
@@ -36,6 +36,7 @@ brew "uv"
 brew "wu-json/asahi/curse"
 brew "wu-json/asahi/pickpocket"
 brew "yq"
+brew "yazi"
 brew "yt-dlp"
 brew "zoxide"
 

--- a/justfile
+++ b/justfile
@@ -39,6 +39,7 @@ stow:
   stow -t ~ nvim
   stow -t ~ pi
   stow -t ~ wezterm
+  stow -t ~ yazi
 
 init: brew stow init-fish
   @echo "✓ Initialization complete!"

--- a/yazi/.config/yazi/theme.toml
+++ b/yazi/.config/yazi/theme.toml
@@ -1,0 +1,21 @@
+# Monochrome theme — clean, low-noise.
+[manager]
+# Cursor styles
+cursor_style = "steady-block"
+
+# Selection
+selected_bg = "#444444"
+
+# Border
+border_style = "#444444"
+
+# Syntect (code preview) theme
+syntect_theme = "base16-ocean.dark"
+
+[status]
+# Progress bar
+progress_bg = "#333333"
+
+[input]
+# Input bar border
+border_style = "#666666"

--- a/yazi/.config/yazi/yazi.toml
+++ b/yazi/.config/yazi/yazi.toml
@@ -1,0 +1,50 @@
+[manager]
+# Show hidden files by default
+show_hidden = true
+# Sort by directory first, then alphabetical (case-insensitive)
+sort_by = "alphabetical"
+sort_dir_first = true
+sort_case_sensitive = false
+# Use vim-like navigation (yazi's default)
+linemode = "size"
+
+[preview]
+# Image preview (requires protocol support)
+image_filter = "lanczos3"
+image_quality = 75
+# Syntax highlighting for code
+syntax_highlighting = true
+# Max file sizes for preview
+max_width = 800
+max_height = 600
+
+[opener]
+# Open images in the built-in image viewer
+image = [
+  { run = 'open "$1"', desc = "Open in default app" },
+]
+# Open archives with built-in support
+archive = []
+
+[open]
+# Rules for opening files with external programs
+rules = [
+  { mime = "text/*", use = "nvim" },
+  { mime = "image/*", use = "open" },
+  { mime = "video/*", use = "open" },
+  { mime = "audio/*", use = "open" },
+]
+
+[open.nvim]
+exec = "nvim"
+block = true
+
+[open.open]
+exec = "open"
+block = false
+
+[tasks]
+# Show task progress
+micro_workers = 5
+macro_workers = 10
+bizarre_retry = 3


### PR DESCRIPTION
## Summary
Adds yazi — a blazing-fast terminal file manager — to the dots setup. Includes Brewfile entry, fish alias (`y`), monochrome-themed config, and stow integration.

## Commentary
- `yazi.toml` — vim keys, hidden files shown, dir-first sort, previews, opens text in nvim
- `theme.toml` — monochrome with `base16-ocean.dark` syntax highlighting
- `config.fish` — `alias y="yazi"`
- `justfile` — `stow -t ~ yazi` wired into the stow recipe