### PR TITLE
chore: remove cursor-cli from brew and dotfiles

### DIFF
--- a/fish/.config/fish/config.fish
+++ b/fish/.config/fish/config.fish
@@ -12,13 +12,8 @@ function gtch
 end
 
 # Brew
-# After upgrades, clear cursor-cli quarantine on macOS (native N-API load). https://forum.cursor.com/t/cursor-agent-merkle-tree-napi-darwin-arm64-node-not-opened/155056
 function b
     brew update && brew upgrade
-    set -l _cursor_cli_caskroom "$(brew --prefix 2>/dev/null)/Caskroom/cursor-cli"
-    if test (uname) = Darwin && test -d "$_cursor_cli_caskroom"
-        xattr -rd com.apple.quarantine "$_cursor_cli_caskroom/"
-    end
 end
 
 # Git

--- a/homebrew/Brewfile
+++ b/homebrew/Brewfile
@@ -41,10 +41,6 @@ brew "yt-dlp"
 brew "zoxide"
 
 cask "claude-code"
-# After install on macOS, `just brew` runs: xattr -rd com.apple.quarantine "$(brew --prefix)/Caskroom/cursor-cli/"
-# (Gatekeeper can block cursor-agent native modules; see forum thread below.)
-# https://forum.cursor.com/t/cursor-agent-merkle-tree-napi-darwin-arm64-node-not-opened/155056
-cask "cursor-cli"
 cask "raycast"
 cask "vlc"
 cask "wezterm@nightly"

--- a/justfile
+++ b/justfile
@@ -1,11 +1,7 @@
 brew_prefix := if os() == "macos" { "/opt/homebrew" } else { "/home/linuxbrew/.linuxbrew" }
 
-# macOS: after bundle, strip quarantine on cursor-cli (merkle-tree NAPI). https://forum.cursor.com/t/cursor-agent-merkle-tree-napi-darwin-arm64-node-not-opened/155056
 brew:
-  brew bundle install --file=homebrew/Brewfile && \
-    if [ "$(uname -s)" = Darwin ] && [ -d "{{brew_prefix}}/Caskroom/cursor-cli" ]; then \
-      xattr -rd com.apple.quarantine "{{brew_prefix}}/Caskroom/cursor-cli/"; \
-    fi
+  brew bundle install --file=homebrew/Brewfile
 
 init-fish:
   grep -qxF "{{brew_prefix}}/bin/fish" /etc/shells || echo "{{brew_prefix}}/bin/fish" | sudo tee -a /etc/shells


### PR DESCRIPTION
## Summary
Uninstall cursor-cli Homebrew cask and remove all references to it from the dotfiles.

## Commentary
Removed the cask entry from the Brewfile along with its quarantine-bypass comments, simplified the brew recipe in the justfile, and cleaned up the quarantine logic from the fish config's brew-update function.